### PR TITLE
1291: Renaming the example RS API

### DIFF
--- a/config/7.3.0/fapi1part2adv/ig/routes/routes-service/01-rs-example-fapi-protected-api.json
+++ b/config/7.3.0/fapi1part2adv/ig/routes/routes-service/01-rs-example-fapi-protected-api.json
@@ -1,7 +1,7 @@
 {
-  "name": "01 - RS Test API",
-  "comment": "Route simulating a Resource Server API endpoint",
-  "condition": "${find(request.uri.path, '^/rs/test/api')}",
+  "name": "01 - RS Example FAPI Protected API",
+  "comment": "Route simulating a Resource Server API protected using FAPI",
+  "condition": "${find(request.uri.path, '^/rs/fapi/api')}",
   "handler": {
     "type": "Chain",
     "config": {


### PR DESCRIPTION
Renaming the example RS API route to make it clearer that this is an example API that is being protected using FAPI.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1291