### PR TITLE
1295: Enhancing the example API response to contain data

### DIFF
--- a/config/7.3.0/fapi1part2adv/ig/routes/routes-service/01-rs-example-fapi-protected-api.json
+++ b/config/7.3.0/fapi1part2adv/ig/routes/routes-service/01-rs-example-fapi-protected-api.json
@@ -67,11 +67,12 @@
           }
         }
       ],
-      "handler": {
-        "type": "StaticResponseHandler",
-        "comment": "Return 204 No Content - simulating a response from an upstream protected resource server",
+      "handler":     {
+        "name": "ExampleRsApiResponseHandler",
+        "type": "ScriptableHandler",
         "config": {
-          "status": 204
+          "type": "application/x-groovy",
+          "file": "ExampleRsApiResponseHandler.groovy"
         }
       }
     }

--- a/config/7.3.0/fapi1part2adv/ig/scripts/groovy/ExampleRsApiResponseHandler.groovy
+++ b/config/7.3.0/fapi1part2adv/ig/scripts/groovy/ExampleRsApiResponseHandler.groovy
@@ -1,0 +1,9 @@
+SCRIPT_NAME = "[ExampleRsApiResponseHandler] "
+logger.debug(SCRIPT_NAME + "Creating example API response...")
+
+// Example response - return some data from the access_token
+Response response = new Response(Status.OK)
+var sub = contexts.oauth2.accessToken.info["sub"]
+response.entity.json = json(object(field("user", sub)))
+
+return response


### PR DESCRIPTION
OIDF conformance suite requires a 200 or 201 response.

Updating the example API route to call a handler which returns a 200 response and has a json payload containing the user's id from the access_token.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1295