### PR TITLE
1335: Fixing Test Trusted Directory to be compatible with IG 2024.3

### DIFF
--- a/config/7.3.0/fapi1part2adv/ig/routes/routes-service/76-jwkms-test-directory-jwks.json
+++ b/config/7.3.0/fapi1part2adv/ig/routes/routes-service/76-jwkms-test-directory-jwks.json
@@ -26,7 +26,7 @@
       "secretsProvider": "TestDirectorySigningKeyStore",
       "purposes": [{
         "secretId": "jwt.signer",
-        "keyUsage": "SIGN"
+        "keyUsage": "VERIFY"
       }]
     }
   }

--- a/secure-api-gateway-core-docker/Dockerfile
+++ b/secure-api-gateway-core-docker/Dockerfile
@@ -23,6 +23,9 @@ COPY --chown=forgerock:root 7.3.0/ig/bin/import-pem-certs.sh /home/forgerock
 
 # Copy all config files into the docker image.
 COPY --chown=forgerock:root 7.3.0/ig/lib /opt/ig/lib
+# Removing the bouncy castle jar that exists in the docker image as it clashes with the version used by SAPI-G.
+# This version clash results in the JwkmsIssueCert.groovy script hanging
+RUN rm -f /opt/ig/lib/bcprov-jdk18on-1.74.jar
 COPY --chown=forgerock:root 7.3.0/ig/scripts /var/ig/scripts/
 COPY --chown=forgerock:root 7.3.0/ig/config /var/ig/config/
 


### PR DESCRIPTION
Removing the bcprov-jdk18on-1.74.jar from the IG Docker image as this clashes with the version used by SAPI-G. This dependency was previously not present in the IG docker image. Going forwards, when we upgrade IG we will need to update the rm command to delete the correct version.

Fixing the Test Trusted Directory JWKS route to set the key usage as VERIFY. The key usage of SIGN is used to expose a private key in a JWKS, which we do not want to do, we only wish to expose the public key portion which clients can use to verify sigs.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1335