### PR TITLE
1117: Rename classes to use Fapi prefix for consistency

### DIFF
--- a/config/7.3.0/fapi1part2adv/ig/routes/routes-service/20-as-dcr-endpoint.json
+++ b/config/7.3.0/fapi1part2adv/ig/routes/routes-service/20-as-dcr-endpoint.json
@@ -57,8 +57,8 @@
         },
         {
           "comment": "Validate that the request will result in an OAuth2 client that is FAPI compliant",
-          "name": "FAPIAdvancedDCRValidationFilter",
-          "type": "FAPIAdvancedDCRValidationFilter",
+          "name": "FapiAdvancedDCRValidationFilter",
+          "type": "FapiAdvancedDCRValidationFilter",
           "config": {
             "certificateRetriever": "ContextCertificateRetriever",
             "supportedSigningAlgorithms": ["PS256"],

--- a/config/7.3.0/fapi1part2adv/ig/scripts/groovy/ProcessRegistration.groovy
+++ b/config/7.3.0/fapi1part2adv/ig/scripts/groovy/ProcessRegistration.groovy
@@ -22,7 +22,7 @@ import static org.forgerock.util.promise.Promises.newResultPromise
  * https://openid.net/specs/openid-connect-registration-1_0.html
  * https://datatracker.ietf.org/doc/html/rfc7591
  *
- * NOTE: This filter should be used AFTER the FAPIAdvancedDCRValidationFilter. That filter will check that the request
+ * NOTE: This filter should be used AFTER the FapiAdvancedDCRValidationFilter. That filter will check that the request
  * is fapi compliant:
  * - validateRedirectUris
  *   - request object must contain redirect_uris field

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/SecureApiGatewayClassAliasResolver.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/SecureApiGatewayClassAliasResolver.java
@@ -36,7 +36,7 @@ import com.forgerock.sapi.gateway.dcr.service.idm.IdmApiClientOrganisationServic
 import com.forgerock.sapi.gateway.dcr.service.idm.IdmApiClientService;
 import com.forgerock.sapi.gateway.dcr.sigvalidation.RegistrationRequestJwtSignatureValidationFilter;
 import com.forgerock.sapi.gateway.fapi.FapiInteractionIdTracingFilter;
-import com.forgerock.sapi.gateway.fapi.v1.FAPIAdvancedDCRValidationFilter;
+import com.forgerock.sapi.gateway.fapi.v1.FapiAdvancedDCRValidationFilter;
 import com.forgerock.sapi.gateway.fapi.v1.authorize.FapiAuthorizeRequestValidationFilter;
 import com.forgerock.sapi.gateway.fapi.v1.authorize.FapiParRequestValidationFilter;
 import com.forgerock.sapi.gateway.jwks.FetchApiClientJwksFilter;
@@ -59,7 +59,7 @@ public class SecureApiGatewayClassAliasResolver implements ClassAliasResolver {
     private static final Map<String, Class<?>> ALIASES = new HashMap<>();
 
     static {
-        ALIASES.put("FAPIAdvancedDCRValidationFilter", FAPIAdvancedDCRValidationFilter.class);
+        ALIASES.put("FapiAdvancedDCRValidationFilter", FapiAdvancedDCRValidationFilter.class);
         ALIASES.put("CaffeineCachingJwkSetService", CaffeineCachingJwkSetService.class);
         ALIASES.put("RestJwkSetService", RestJwkSetService.class);
         ALIASES.put("RsaJwtSignatureValidator", RsaJwtSignatureValidator.class);

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/common/ResponseFactory.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/common/ResponseFactory.java
@@ -29,7 +29,7 @@ import org.forgerock.util.Reject;
 import com.forgerock.sapi.gateway.common.rest.ContentTypeFormatter;
 import com.forgerock.sapi.gateway.common.rest.ContentTypeFormatterFactory;
 import com.forgerock.sapi.gateway.common.rest.ContentTypeNegotiator;
-import com.forgerock.sapi.gateway.fapi.FAPIUtils;
+import com.forgerock.sapi.gateway.fapi.FapiUtils;
 
 public class ResponseFactory {
     private final ContentTypeNegotiator contentTypeNegotiator;
@@ -55,7 +55,7 @@ public class ResponseFactory {
     public Response getInternalServerErrorResponse(Request request, List<String> acceptValues) {
         Map<String, String> errorFields = new LinkedHashMap<>();
         errorFields.put("error", "Server unable to process request");
-        final Optional<String> fapiInteractionId = FAPIUtils.getFapiInteractionId(request);
+        final Optional<String> fapiInteractionId = FapiUtils.getFapiInteractionId(request);
         if (fapiInteractionId.isPresent()) {
             errorFields.put("trace_id", fapiInteractionId.get());
         }

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/fapi/FapiInteractionIdTracingFilter.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/fapi/FapiInteractionIdTracingFilter.java
@@ -15,7 +15,7 @@
  */
 package com.forgerock.sapi.gateway.fapi;
 
-import static com.forgerock.sapi.gateway.fapi.FAPIUtils.X_FAPI_INTERACTION_ID;
+import static com.forgerock.sapi.gateway.fapi.FapiUtils.X_FAPI_INTERACTION_ID;
 
 import java.util.Optional;
 
@@ -57,7 +57,7 @@ public class FapiInteractionIdTracingFilter implements Filter {
 
     @Override
     public Promise<Response, NeverThrowsException> filter(Context context, Request request, Handler next) {
-        final Optional<String> optionalInteractionId = FAPIUtils.getFapiInteractionId(request);
+        final Optional<String> optionalInteractionId = FapiUtils.getFapiInteractionId(request);
         if (optionalInteractionId.isPresent()) {
             // Add the x-fapi-interaction-id to the MDC context for logging purposes, ensure the previously set value is restored
             final String previousMdcFapiInteractionId = MDC.get(X_FAPI_INTERACTION_ID);

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/fapi/FapiUtils.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/fapi/FapiUtils.java
@@ -20,7 +20,7 @@ import java.util.Optional;
 import org.forgerock.http.protocol.Request;
 import org.forgerock.util.Reject;
 
-public class FAPIUtils {
+public class FapiUtils {
 
     public static final String X_FAPI_INTERACTION_ID = "x-fapi-interaction-id";
 

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/fapi/v1/FapiAdvancedDCRValidationFilter.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/fapi/v1/FapiAdvancedDCRValidationFilter.java
@@ -122,7 +122,7 @@ import com.forgerock.sapi.gateway.mtls.HeaderCertificateRetriever;
  * IG Config required to create this filter:
  * <pre>
  *     {@code {
- *         "type": "FAPIAdvancedDCRValidationFilter",
+ *         "type": "FapiAdvancedDCRValidationFilter",
  *         "config": {
  *             "certificateRetriever"                   : CertificateRetriever [OPTIONAL]
  *             "clientTlsCertHeader"                    : String               [OPTIONAL] [DEPRECATED]
@@ -153,9 +153,9 @@ import com.forgerock.sapi.gateway.mtls.HeaderCertificateRetriever;
  * registrationObjectSigningFieldNames configures which fields inside the registration request object should be validated
  * against the supportedSigningAlgorithms
  */
-public class FAPIAdvancedDCRValidationFilter implements Filter {
+public class FapiAdvancedDCRValidationFilter implements Filter {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(FAPIAdvancedDCRValidationFilter.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(FapiAdvancedDCRValidationFilter.class);
 
     /**
      * The HTTP methods to apply FAPI validation to.
@@ -233,7 +233,7 @@ public class FAPIAdvancedDCRValidationFilter implements Filter {
      * The filter should be constructed using the {@link Heaplet}.
      * This object is complex to create, the Heaplet follows the builder pattern to produce a coherent object.
      */
-    private FAPIAdvancedDCRValidationFilter() {
+    private FapiAdvancedDCRValidationFilter() {
         errorResponseFactory = new ErrorResponseFactory();
     }
 
@@ -487,14 +487,14 @@ public class FAPIAdvancedDCRValidationFilter implements Filter {
         }
     }
 
-    /** Creates and initializes a FAPIAdvancedDCRValidationFilter */
+    /** Creates and initializes a FapiAdvancedDCRValidationFilter */
     public static class Heaplet extends GenericHeaplet {
 
         private final Logger logger = LoggerFactory.getLogger(getClass());
 
         @Override
         public Object create() throws HeapException {
-            final FAPIAdvancedDCRValidationFilter filter = new FAPIAdvancedDCRValidationFilter();
+            final FapiAdvancedDCRValidationFilter filter = new FapiAdvancedDCRValidationFilter();
 
             final List<String> supportedSigningAlgorithms = config.get("supportedSigningAlgorithms")
                                                                    .as(evaluatedWithHeapProperties())
@@ -531,7 +531,7 @@ public class FAPIAdvancedDCRValidationFilter implements Filter {
                 final String clientCertHeaderName = config.get("clientTlsCertHeader").required().asString();
                 logger.warn("{} config option clientTlsCertHeader is deprecated, use certificateRetriever instead. " +
                             "This option needs to contain a value which is a reference to a {} object on the heap",
-                            FAPIAdvancedDCRValidationFilter.class.getSimpleName(), CertificateRetriever.class);
+                            FapiAdvancedDCRValidationFilter.class.getSimpleName(), CertificateRetriever.class);
                 filter.setClientCertificateRetriever(new HeaderCertificateRetriever(clientCertHeaderName));
             }
 

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/metrics/RouteMetricsFilter.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/metrics/RouteMetricsFilter.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
 
 import com.forgerock.sapi.gateway.dcr.filter.FetchApiClientFilter;
 import com.forgerock.sapi.gateway.dcr.models.ApiClient;
-import com.forgerock.sapi.gateway.fapi.FAPIUtils;
+import com.forgerock.sapi.gateway.fapi.FapiUtils;
 import com.forgerock.sapi.gateway.trusteddirectories.TrustedDirectoryService;
 import com.google.common.base.Stopwatch;
 import com.google.common.base.Ticker;
@@ -119,7 +119,7 @@ public class RouteMetricsFilter implements Filter {
         metricEvent.setHttpStatusCode(response.getStatus().getCode());
         metricEvent.setSuccessResponse(isSuccessResponse(response.getStatus()));
 
-        FAPIUtils.getFapiInteractionId(request).ifPresent(metricEvent::setFapiInteractionId);
+        FapiUtils.getFapiInteractionId(request).ifPresent(metricEvent::setFapiInteractionId);
 
         stopwatch.stop();
         metricEvent.setResponseTimeMillis(stopwatch.elapsed(TimeUnit.MILLISECONDS));

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/fapi/FapiInteractionIdTracingFilterTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/fapi/FapiInteractionIdTracingFilterTest.java
@@ -15,7 +15,7 @@
  */
 package com.forgerock.sapi.gateway.fapi;
 
-import static com.forgerock.sapi.gateway.fapi.FAPIUtils.X_FAPI_INTERACTION_ID;
+import static com.forgerock.sapi.gateway.fapi.FapiUtils.X_FAPI_INTERACTION_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/fapi/FapiUtilsTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/fapi/FapiUtilsTest.java
@@ -24,14 +24,14 @@ import org.forgerock.http.header.GenericHeader;
 import org.forgerock.http.protocol.Request;
 import org.junit.jupiter.api.Test;
 
-class FAPIUtilsTest {
+class FapiUtilsTest {
     @Test
     void getFapiInteractionId() {
-        assertFalse(FAPIUtils.getFapiInteractionId(new Request()).isPresent(), "No x-fapi-interaction-id should be found");
+        assertFalse(FapiUtils.getFapiInteractionId(new Request()).isPresent(), "No x-fapi-interaction-id should be found");
 
         final String fapiInteractionId = UUID.randomUUID().toString();
         final Request requestWithFapiInteractionIdHeader = new Request().addHeaders(
                 new GenericHeader("x-fapi-interaction-id", fapiInteractionId));
-        assertEquals(fapiInteractionId, FAPIUtils.getFapiInteractionId(requestWithFapiInteractionIdHeader).get());
+        assertEquals(fapiInteractionId, FapiUtils.getFapiInteractionId(requestWithFapiInteractionIdHeader).get());
     }
 }

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/fapi/v1/FapiAdvancedDCRValidationFilterTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/fapi/v1/FapiAdvancedDCRValidationFilterTest.java
@@ -66,7 +66,7 @@ import org.junit.jupiter.api.Test;
 import com.forgerock.sapi.gateway.dcr.common.exceptions.ValidationException;
 import com.forgerock.sapi.gateway.dcr.common.Validator;
 import com.forgerock.sapi.gateway.dcr.common.DCRErrorCode;
-import com.forgerock.sapi.gateway.fapi.v1.FAPIAdvancedDCRValidationFilter.Heaplet;
+import com.forgerock.sapi.gateway.fapi.v1.FapiAdvancedDCRValidationFilter.Heaplet;
 import com.forgerock.sapi.gateway.mtls.HeaderCertificateRetriever;
 import com.forgerock.sapi.gateway.util.TestHandlers.TestSuccessResponseHandler;
 import com.nimbusds.jose.JOSEException;
@@ -76,7 +76,7 @@ import com.nimbusds.jose.crypto.RSASSASigner;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 
-class FAPIAdvancedDCRValidationFilterTest {
+class FapiAdvancedDCRValidationFilterTest {
 
     private static final String CERT_HEADER_NAME = "x-cert";
 
@@ -88,7 +88,7 @@ class FAPIAdvancedDCRValidationFilterTest {
 
     private TestSuccessResponseHandler successHandler;
 
-    private FAPIAdvancedDCRValidationFilter fapiValidationFilter;
+    private FapiAdvancedDCRValidationFilter fapiValidationFilter;
 
     @BeforeAll
     public static void beforeAll() throws NoSuchAlgorithmException {
@@ -119,11 +119,11 @@ class FAPIAdvancedDCRValidationFilterTest {
     }
 
     /**
-     * Uses the Heaplet to create a FAPIAdvancedDCRValidationFilter with the default configuration.
+     * Uses the Heaplet to create a FapiAdvancedDCRValidationFilter with the default configuration.
      */
-    private static FAPIAdvancedDCRValidationFilter createDefaultFapiFilter() throws HeapException {
+    private static FapiAdvancedDCRValidationFilter createDefaultFapiFilter() throws HeapException {
         final JsonValue filterConfig = json(object(field("clientTlsCertHeader", CERT_HEADER_NAME)));
-        return (FAPIAdvancedDCRValidationFilter) new FAPIAdvancedDCRValidationFilter.Heaplet()
+        return (FapiAdvancedDCRValidationFilter) new FapiAdvancedDCRValidationFilter.Heaplet()
                                                                                     .create(Name.of("fapiTest"),
                                                                                             filterConfig, EMPTY_HEAP);
     }
@@ -155,7 +155,7 @@ class FAPIAdvancedDCRValidationFilterTest {
     }
 
     private void submitRequestAndValidateSuccessful(String httpMethod, Map<String, Object> validRegRequestObj,
-            String testCertPem, FAPIAdvancedDCRValidationFilter filter) throws Exception {
+            String testCertPem, FapiAdvancedDCRValidationFilter filter) throws Exception {
         final TransactionIdContext context = new TransactionIdContext(null, new TransactionId("1234"));
         final Request request = new Request().setMethod(httpMethod);
         request.addHeaders(new GenericHeader(CERT_HEADER_NAME, URLEncoder.encode(testCertPem, StandardCharsets.UTF_8)));
@@ -522,7 +522,7 @@ class FAPIAdvancedDCRValidationFilterTest {
                                                                      "request_object_signing_alg",
                                                                      "additional_signing_field_to_validate"))));
 
-            final FAPIAdvancedDCRValidationFilter filter = (FAPIAdvancedDCRValidationFilter) new Heaplet().create(Name.of("fapiTest"), filterConfig, EMPTY_HEAP);
+            final FapiAdvancedDCRValidationFilter filter = (FapiAdvancedDCRValidationFilter) new Heaplet().create(Name.of("fapiTest"), filterConfig, EMPTY_HEAP);
 
             final Map<String, Object> validRegRequestObj = new HashMap<>(VALID_REG_REQUEST_OBJ);
             validRegRequestObj.put("additional_signing_field_to_validate", "PS256"); // Add a value for the extra signing field that was configured via conf
@@ -545,7 +545,7 @@ class FAPIAdvancedDCRValidationFilterTest {
                                     "request_object_signing_alg",
                                     "additional_signing_field_to_validate"))));
 
-            final FAPIAdvancedDCRValidationFilter filter = (FAPIAdvancedDCRValidationFilter) new Heaplet().create(Name.of("fapiTest"), filterConfig, heap);
+            final FapiAdvancedDCRValidationFilter filter = (FapiAdvancedDCRValidationFilter) new Heaplet().create(Name.of("fapiTest"), filterConfig, heap);
 
             final Map<String, Object> validRegRequestObj = new HashMap<>(VALID_REG_REQUEST_OBJ);
             validRegRequestObj.put("additional_signing_field_to_validate", "PS256"); // Add a value for the extra signing field that was configured via conf


### PR DESCRIPTION
Fapi is the preferred class prefix when referring to FAPI standard.

Renaming the following:
- FAPIUtils -> FapiUtils
- FAPIAdvancedDCRValidationFilter -> FapiAdvancedDCRValidationFilter

https://github.com/SecureApiGateway/SecureApiGateway/issues/1117