### PR TITLE
1116: Rename RegistrationRequestEntityValidatorFilter to RegistrationRequestBuilderFilter

### DIFF
--- a/config/7.3.0/fapi1part2adv/ig/routes/routes-service/20-as-dcr-endpoint.json
+++ b/config/7.3.0/fapi1part2adv/ig/routes/routes-service/20-as-dcr-endpoint.json
@@ -39,8 +39,8 @@
         },
         {
           "comment": "Pull the registration request from the entity and create a RegistrationRequest object context attribute",
-          "name": "RegistrationRequestEntityValidationFilter",
-          "type": "RegistrationRequestEntityValidatorFilter",
+          "name": "RegistrationRequestBuilderFilter",
+          "type": "RegistrationRequestBuilderFilter",
           "config": {
             "trustedDirectoryService": "TrustedDirectoriesService"
           }

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/SecureApiGatewayClassAliasResolver.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/SecureApiGatewayClassAliasResolver.java
@@ -31,7 +31,7 @@ import com.forgerock.sapi.gateway.dcr.filter.ManageApiClientFilter;
 import com.forgerock.sapi.gateway.dcr.filter.ManageApiClientFilter.PathParamClientIdRequestParameterLocator;
 import com.forgerock.sapi.gateway.dcr.filter.ManageApiClientFilter.QueryParamClientIdRequestParameterLocator;
 import com.forgerock.sapi.gateway.dcr.filter.ParResponseFetchApiClientFilterHeaplet;
-import com.forgerock.sapi.gateway.dcr.request.RegistrationRequestEntityValidatorFilter;
+import com.forgerock.sapi.gateway.dcr.request.RegistrationRequestBuilderFilter;
 import com.forgerock.sapi.gateway.dcr.service.idm.IdmApiClientOrganisationService;
 import com.forgerock.sapi.gateway.dcr.service.idm.IdmApiClientService;
 import com.forgerock.sapi.gateway.dcr.sigvalidation.RegistrationRequestJwtSignatureValidationFilter;
@@ -70,7 +70,7 @@ public class SecureApiGatewayClassAliasResolver implements ClassAliasResolver {
         ALIASES.put("TransportCertValidationFilter", TransportCertValidationFilter.class);
         ALIASES.put("DefaultTransportCertValidator", DefaultTransportCertValidator.class);
         ALIASES.put("RegistrationRequestJwtSignatureValidationFilter", RegistrationRequestJwtSignatureValidationFilter.class);
-        ALIASES.put("RegistrationRequestEntityValidatorFilter", RegistrationRequestEntityValidatorFilter.class);
+        ALIASES.put("RegistrationRequestBuilderFilter", RegistrationRequestBuilderFilter.class);
         ALIASES.put("ConsentRequestAccessAuthorisationFilter", ConsentRequestAccessAuthorisationFilter.class);
         ALIASES.put("TokenEndpointTransportCertValidationFilter", TokenEndpointTransportCertValidationFilter.class);
         ALIASES.put("SapiLogAttachedExceptionFilter", SapiLogAttachedExceptionFilterHeaplet.class);

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/request/RegistrationRequestBuilderFilter.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/request/RegistrationRequestBuilderFilter.java
@@ -52,9 +52,9 @@ import com.forgerock.sapi.gateway.trusteddirectories.TrustedDirectoryService;
  * the body of a request to the /registration endpoint. If the {@code RegistationRequest} can successfully be built
  * then it is placed on the attributes context for use by subsequent filters
  */
-public class RegistrationRequestEntityValidatorFilter implements Filter {
+public class RegistrationRequestBuilderFilter implements Filter {
 
-    private static final Logger log = LoggerFactory.getLogger(RegistrationRequestEntityValidatorFilter.class);
+    private static final Logger log = LoggerFactory.getLogger(RegistrationRequestBuilderFilter.class);
     private final RegistrationRequestEntitySupplier registrationEntitySupplier;
     private final RegistrationRequest.Builder registrationRequestBuilder;
     private final ResponseFactory responseFactory;
@@ -70,7 +70,7 @@ public class RegistrationRequestEntityValidatorFilter implements Filter {
      * @param responseFactory used to create a suitably formatted response should an error occur while processing the
      *                        registration request
      */
-    public RegistrationRequestEntityValidatorFilter(RegistrationRequestEntitySupplier registrationEntitySupplier,
+    public RegistrationRequestBuilderFilter(RegistrationRequestEntitySupplier registrationEntitySupplier,
             RegistrationRequest.Builder registrationRequestBuilder, ResponseFactory responseFactory) {
         Reject.ifNull(registrationEntitySupplier, "registrationEntitySupplier must be provided");
         Reject.ifNull(registrationRequestBuilder, "registrationRequestBuilder must be provided");
@@ -106,7 +106,7 @@ public class RegistrationRequestEntityValidatorFilter implements Filter {
     }
 
     /**
-     * Heaplet used to create {@link RegistrationRequestEntityValidatorFilter} objects
+     * Heaplet used to create {@link RegistrationRequestBuilderFilter} objects
      *
      * Mandatory fields:
      *  - trustedDirectoryService: the name of the service used to provide the trusted directory config
@@ -143,7 +143,7 @@ public class RegistrationRequestEntityValidatorFilter implements Filter {
             final ResponseFactory responseFactory = new ResponseFactory(contentTypeNegotiator,
                     contentTypeFormatterFactory);
 
-            return new RegistrationRequestEntityValidatorFilter( registrationEntitySupplier,
+            return new RegistrationRequestBuilderFilter( registrationEntitySupplier,
                     registrationRequestBuilder, responseFactory);
         }
     }

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/request/RegistrationRequestBuilderFilterTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/request/RegistrationRequestBuilderFilterTest.java
@@ -51,9 +51,9 @@ import com.forgerock.sapi.gateway.jws.JwtDecoder;
 import com.forgerock.sapi.gateway.trusteddirectories.TrustedDirectoryService;
 import com.forgerock.sapi.gateway.trusteddirectories.TrustedDirectoryTestFactory;
 
-class RegistrationRequestEntityValidatorFilterTest {
+class RegistrationRequestBuilderFilterTest {
 
-    private RegistrationRequestEntityValidatorFilter filter;
+    private RegistrationRequestBuilderFilter filter;
     private final RegistrationRequestEntitySupplier reqRequestSupplier = mock(RegistrationRequestEntitySupplier.class);
     private static RegistrationRequest.Builder registrationRequestBuilder ;
     private static final JwtDecoder jwtDecoder = new JwtDecoder();
@@ -71,7 +71,7 @@ class RegistrationRequestEntityValidatorFilterTest {
     void setUp() {
         when(handler.handle(any(Context.class), any(Request.class)))
                 .thenReturn(Promises.newResultPromise(new Response(Status.OK)));
-        filter = new RegistrationRequestEntityValidatorFilter(reqRequestSupplier, registrationRequestBuilder,
+        filter = new RegistrationRequestBuilderFilter(reqRequestSupplier, registrationRequestBuilder,
                 responseFactory);
     }
 


### PR DESCRIPTION
The filter builds RegistrationRequest objects from the HTTP request and adds them to the Context so that other filters can process them, renaming the RegistrationRequestEntityValidatorFilter filter to RegistrationRequestBuilderFilter to better capture what it is doing.

The previous name was misleading as it was not applying any validation rules to the request.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1116