### PR TITLE
1377: Use version discovery functionality of AmService

### DIFF
--- a/config/7.3.0/fapi1part2adv/ig/config/dev/config/config.json
+++ b/config/7.3.0/fapi1part2adv/ig/config/dev/config/config.json
@@ -195,7 +195,6 @@
       "config" : {
         "url" : "https://&{identity.platform.fqdn}/am",
         "realm" : "/&{am.realm}",
-        "version" : "7.3.0",
         "agent" : {
           "username" : "ig-agent",
           "passwordSecretId" : "ig.agent.password"

--- a/config/7.3.0/fapi1part2adv/ig/config/prod/config/config.json
+++ b/config/7.3.0/fapi1part2adv/ig/config/prod/config/config.json
@@ -183,7 +183,6 @@
       "config" : {
         "url" : "https://&{identity.platform.fqdn}/am",
         "realm" : "/&{am.realm}",
-        "version" : "7.3.0",
         "agent" : {
           "username" : "ig-agent",
           "passwordSecretId" : "ig.agent.password"


### PR DESCRIPTION
Removing the optional version configuration of AmService, using the AM version discovery functionality in IG.

This avoid having a misconfiguration when the AM version is upgraded / is different in different environments.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1377