### PR TITLE
1379: Retrieve client_id from request object JWT for PAR

### DIFF
--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/filter/ParResponseFetchApiClientFilterHeaplet.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/filter/ParResponseFetchApiClientFilterHeaplet.java
@@ -18,6 +18,7 @@ package com.forgerock.sapi.gateway.dcr.filter;
 import static com.forgerock.sapi.gateway.dcr.filter.AuthorizeResponseFetchApiClientFilter.*;
 import static org.forgerock.openig.util.JsonValues.requiredHeapObject;
 
+import org.forgerock.http.protocol.Request;
 import org.forgerock.openig.heap.GenericHeaplet;
 import org.forgerock.openig.heap.HeapException;
 
@@ -26,7 +27,7 @@ import com.forgerock.sapi.gateway.dcr.service.ApiClientService;
 
 /**
  * Heaplet for creating a ParResponseFetchApiClientFilter, this is an alias for the AuthorizeResponseFetchApiClientFilter
- * that has been configured to retrieve the client_id from the HTTP Request's Form.
+ * that has been configured to retrieve the client_id from the request JWT in the {@link Request}'s Form entity.
  * <p>
  * Mandatory config:
  * - apiClientService: reference to an {@link ApiClientService} implementation heap object to use to retrieve the {@link ApiClient}
@@ -48,6 +49,6 @@ public class ParResponseFetchApiClientFilterHeaplet extends GenericHeaplet {
     @Override
     public Object create() throws HeapException {
         final ApiClientService apiClientService = config.get("apiClientService").as(requiredHeapObject(heap, ApiClientService.class));
-        return new AuthorizeResponseFetchApiClientFilter(apiClientService, formClientIdRetriever());
+        return new AuthorizeResponseFetchApiClientFilter(apiClientService, formRequestJwtClientIdRetriever());
     }
 }


### PR DESCRIPTION
client_id is now extracted from the request JWT's claim of the same name.

The previous impl was incorrect, as it assumed that the client_id was always present as a form param. This is only the case due to OPENAM-21910 bug in AM. The new impl will is correct as per the spec and will continue to work when the bug is fixed in AM.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1379