### PR TITLE
1387: Renaming FetchApiClientResourcesChain to ValidateApiClientMtlsCertChain

### DIFF
--- a/config/7.3.0/fapi1part2adv/ig/config/dev/config/config.json
+++ b/config/7.3.0/fapi1part2adv/ig/config/dev/config/config.json
@@ -102,9 +102,9 @@
       "capture" : [ "response", "request" ]
     },
     {
-      "name": "FetchApiClientResourcesChain",
+      "name": "ValidateApiClientMtlsCertChain",
       "type": "ChainOfFilters",
-      "comment": "This filter chain will set the apiClient, apiClientJwkSet and trustedDirectory attributes in the context based on the client_id of the access_token",
+      "comment": "This filter chain validates the ApiClient's MTLS cert using the Trusted Directory, it first fetches all of the resources it needs to perform the validation",
       "config" : {
         "filters": [
           {

--- a/config/7.3.0/fapi1part2adv/ig/config/prod/config/config.json
+++ b/config/7.3.0/fapi1part2adv/ig/config/prod/config/config.json
@@ -90,9 +90,9 @@
       "capture" : [ "response", "request" ]
     },
     {
-      "name": "FetchApiClientResourcesChain",
+      "name": "ValidateApiClientMtlsCertChain",
       "type": "ChainOfFilters",
-      "comment": "This filter chain will set the apiClient, apiClientJwkSet and trustedDirectory attributes in the context based on the client_id of the access_token",
+      "comment": "This filter chain validates the ApiClient's MTLS cert using the Trusted Directory, it first fetches all of the resources it needs to perform the validation",
       "config" : {
         "filters": [
           {

--- a/config/7.3.0/fapi1part2adv/ig/routes/routes-service/01-rs-example-fapi-protected-api.json
+++ b/config/7.3.0/fapi1part2adv/ig/routes/routes-service/01-rs-example-fapi-protected-api.json
@@ -53,7 +53,7 @@
             }
           }
         },
-        "FetchApiClientResourcesChain",
+        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",


### PR DESCRIPTION
The MTLS validation is the main purpose of the chain, the resources are fetched in order to carry this out.

The new name makes validation being carried out more obvious when the chain name is read in a route definition.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1387