### PR TITLE
1393: Using URI instead of URL for jwks_uri and redirect_uri values

### DIFF
--- a/config/7.3.0/fapi1part2adv/ig/scripts/groovy/ProcessRegistration.groovy
+++ b/config/7.3.0/fapi1part2adv/ig/scripts/groovy/ProcessRegistration.groovy
@@ -188,7 +188,7 @@ switch (method.toUpperCase()) {
 
         // Verify that the tls transport cert is registered for the TPP's software statement
         if ( softwareStatement.hasJwksUri() ) {
-            URL softwareStatementJwksUri = softwareStatement.getJwksUri();
+            URI softwareStatementJwksUri = softwareStatement.getJwksUri();
             regRequestClaimsSet.setClaim("jwks_uri", softwareStatementJwksUri.toString());
 
             // AM doesn't understand JWS encoded registration requests, so we need to convert the jwt JSON and pass it on
@@ -200,7 +200,7 @@ switch (method.toUpperCase()) {
             logger.debug(SCRIPT_NAME + "Checking cert against remote jwks: " + softwareStatementJwksUri)
             return jwkSetService.getJwkSet(softwareStatementJwksUri)
                     .thenCatchAsync(e -> {
-                        String errorDescription = "Unable to get jwks from url: " + softwareStatementJwksUri
+                        String errorDescription = "Unable to get jwks from uri: " + softwareStatementJwksUri
                         logger.warn(SCRIPT_NAME + "Failed to get jwks due to exception: " + errorDescription, e)
                         return newResultPromise(errorResponseFactory.invalidClientMetadataErrorResponse(errorDescription))
                     })
@@ -271,13 +271,12 @@ switch (method.toUpperCase()) {
  * https://openbankinguk.github.io/dcr-docs-pub/v3.2/dynamic-client-registration.html
  */
 private void validateRegistrationRedirectUris(RegistrationRequest registrationRequest) {
-    List<URL> regRedirectUris = registrationRequest.getRedirectUris()
+    List<URI> regRedirectUris = registrationRequest.getRedirectUris()
     SoftwareStatement softwareStatement = registrationRequest.getSoftwareStatement()
-    List<URL> ssaRedirectUris = softwareStatement.getRedirectUris()
+    List<URI> ssaRedirectUris = softwareStatement.getRedirectUris()
 
-    for(URL regRequestRedirectUri : regRedirectUris){
-        if(!"https".equals(regRequestRedirectUri.getProtocol())){
-
+    for(URI regRequestRedirectUri : regRedirectUris){
+        if(!"https".equals(regRequestRedirectUri.getScheme())){
             throw new IllegalStateException("invalid registration request redirect_uris value: " + regRedirect + " must use https")
         }
 

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/common/jwt/ClaimsSetFacade.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/common/jwt/ClaimsSetFacade.java
@@ -15,8 +15,8 @@
  */
 package com.forgerock.sapi.gateway.common.jwt;
 
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -118,7 +118,7 @@ public class ClaimsSetFacade {
         }
     }
 
-    public List<URL> getRequiredUriListClaim(String claimName) throws JwtException {
+    public List<URI> getRequiredUriListClaim(String claimName) throws JwtException {
         checkClaimName(claimName);
         try {
             JsonValue claimValue = this.claimsSet.get(claimName);
@@ -127,14 +127,14 @@ public class ClaimsSetFacade {
             }
             if (claimValue.isList()){
                 List<Object> claimValueList = claimValue.asList();
-                List<URL> uriList = new ArrayList<>(claimValueList.size());
+                List<URI> uriList = new ArrayList<>(claimValueList.size());
                 for(int index = 0; index < claimValueList.size(); index++){
                     Object claim = claimValueList.get(index);
                     try {
-                        URL url = new URL((String)claim);
-                        uriList.add(index, url);
-                    } catch (MalformedURLException e) {
-                        throw new JwtException("claim of name '" + claimName + "' is expected to hold valid URLs: " + e.getMessage());
+                        final URI uri = new URI((String)claim);
+                        uriList.add(index, uri);
+                    } catch (URISyntaxException e) {
+                        throw new JwtException("claim of name '" + claimName + "' is expected to hold valid URIs: " + e.getMessage());
                     }
                 }
                 return uriList;
@@ -148,24 +148,24 @@ public class ClaimsSetFacade {
 
 
     /**
-     * Get the value of a string claim from the claims set and convert it to a URL
+     * Get the value of a string claim from the claims set and convert it to a URI
      *
-     * @param claimName the name of the string claim that is expected to hold a valid URL
-     * @return a {@code URL}
+     * @param claimName the name of the string claim that is expected to hold a valid URI
+     * @return a {@code URI}
      * @throws JwtException if the claim does not exist, or holds an empty string, or is not a string, or if the value
      *                      of the string is not a valid URL
      */
-    public URL getStringClaimAsURL(String claimName) throws JwtException {
+    public URI getStringClaimAsURI(String claimName) throws JwtException {
         checkClaimName(claimName);
         try {
             String claimValueAsString = this.claimsSet.getClaim(claimName, String.class);
             if (StringUtils.isNullOrEmpty(claimValueAsString)) {
-                throw new JwtException("Jwt claim '" + claimName + "' must be valid URL as a String value");
+                throw new JwtException("Jwt claim '" + claimName + "' must be valid URI as a String value");
             }
             try {
-                return new URL(claimValueAsString);
-            } catch (MalformedURLException e) {
-                throw new JwtException("Jwt claim '" + claimName + "' must be a valid URL as a String Value");
+                return new URI(claimValueAsString);
+            } catch (URISyntaxException e) {
+                throw new JwtException("Jwt claim '" + claimName + "' must be a valid URI as a String Value");
             }
         } catch (ClassCastException exception) {
             throw new JwtException("Jwt must contain URL claim '" + claimName + "'");

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/models/RegistrationRequest.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/models/RegistrationRequest.java
@@ -15,7 +15,7 @@
  */
 package com.forgerock.sapi.gateway.dcr.models;
 
-import java.net.URL;
+import java.net.URI;
 import java.util.List;
 import java.util.Optional;
 
@@ -42,7 +42,7 @@ public class RegistrationRequest extends SapiJwt {
     public static final String REGISTRATION_REQUEST_KEY = "registrationRequest";
 
     private final SoftwareStatement softwareStatement;
-    private final List<URL> redirectUris;
+    private final List<URI> redirectUris;
 
     public RegistrationRequest(Builder builder){
         super(builder);
@@ -71,9 +71,9 @@ public class RegistrationRequest extends SapiJwt {
     }
 
     /**
-     * @return the redirect urls specified in the registration request
+     * @return the redirect uris specified in the registration request
      */
-    public List<URL> getRedirectUris(){
+    public List<URI> getRedirectUris(){
         return this.redirectUris;
     }
 
@@ -85,7 +85,7 @@ public class RegistrationRequest extends SapiJwt {
         private static final Logger log = LoggerFactory.getLogger(Builder.class);
         private final SoftwareStatement.Builder softwareStatementBuilder;
         private SoftwareStatement softwareStatement;
-        private List<URL> redirectUris;
+        private List<URI> redirectUris;
 
         /**
          * Construct a {@code Builder)

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/models/SoftwareStatement.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/models/SoftwareStatement.java
@@ -15,7 +15,7 @@
  */
 package com.forgerock.sapi.gateway.dcr.models;
 
-import java.net.URL;
+import java.net.URI;
 import java.util.List;
 
 import org.forgerock.json.JsonException;
@@ -41,15 +41,15 @@ import com.forgerock.sapi.gateway.trusteddirectories.TrustedDirectoryService;
 public class SoftwareStatement extends SapiJwt {
 
     // The jwks_uri of the trusted directory against which the Software Statement signature may be validated
-    private final URL trustedDirectoryJwksUrl;
+    private final URI trustedDirectoryJwksUri;
     private final String orgId;
     private final String orgName;
     private final String softwareId;
     private final String clientName;
     private final boolean hasJwksUri;
-    private final URL jwksUri;
+    private final URI jwksUri;
     private final JWKSet jwksSet;
-    private final List<URL> redirectUris;
+    private final List<URI> redirectUris;
     private final List<String> roles;
 
     /**
@@ -67,15 +67,15 @@ public class SoftwareStatement extends SapiJwt {
         this.jwksUri = builder.jwksUri;
         this.jwksSet = builder.jwkSet;
         this.redirectUris = builder.redirectUris;
-        this.trustedDirectoryJwksUrl = builder.trustedDirectoryJwksUrl;
+        this.trustedDirectoryJwksUri = builder.trustedDirectoryJwksUri;
         this.roles = builder.roles;
     }
 
     /**
-     * @return the URL against which the software statement assertions signature may be validated
+     * @return the URI against which the software statement assertions signature may be validated
      */
-    public URL getTrustedDirectoryJwksUrl() {
-        return trustedDirectoryJwksUrl;
+    public URI getTrustedDirectoryJwksUri() {
+        return trustedDirectoryJwksUri;
     }
 
     /**
@@ -115,11 +115,11 @@ public class SoftwareStatement extends SapiJwt {
     }
 
     /**
-     * @return if hasJwksUri returns true, then this will return a URL that defines the URL at which the JWKS that holds
-     * all of the public keys associated with the software statement. The JWKS obtained from this URL can be used to
+     * @return if hasJwksUri returns true, then this will return a URI that defines the URI at which the JWKS that holds
+     * all of the public keys associated with the software statement. The JWKS obtained from this URI can be used to
      * validate all the transport, signing keys and encryption keys that will be used by the ApiClient
      */
-    public URL getJwksUri() {
+    public URI getJwksUri() {
         return jwksUri;
     }
 
@@ -136,7 +136,7 @@ public class SoftwareStatement extends SapiJwt {
      * @return the list of redirect uris registered with the trusted directory as being valid for this software
      * statement
      */
-    public List<URL> getRedirectUris() {
+    public List<URI> getRedirectUris() {
         return this.redirectUris;
     }
 
@@ -158,10 +158,10 @@ public class SoftwareStatement extends SapiJwt {
         private String softwareId;
         private String clientName;
         private boolean hasJwksUri;
-        private URL jwksUri;
+        private URI jwksUri;
         private JWKSet jwkSet;
-        private URL trustedDirectoryJwksUrl;
-        private List<URL> redirectUris;
+        private URI trustedDirectoryJwksUri;
+        private List<URI> redirectUris;
         private List<String> roles;
 
         public Builder(TrustedDirectoryService trustedDirectoryService, JwtDecoder jwtDecoder) {
@@ -199,7 +199,7 @@ public class SoftwareStatement extends SapiJwt {
         private void getSsaSpecificFieldsFromJwt(TrustedDirectory trustedDirectory) throws JwtException {
             if (trustedDirectory.softwareStatementHoldsJwksUri()) {
                 this.hasJwksUri = true;
-                this.jwksUri = claimsSet.getStringClaimAsURL(trustedDirectory.getSoftwareStatementJwksUriClaimName());
+                this.jwksUri = claimsSet.getStringClaimAsURI(trustedDirectory.getSoftwareStatementJwksUriClaimName());
             } else {
                 this.hasJwksUri = false;
                 this.jwkSet = getJwkSet();
@@ -208,7 +208,7 @@ public class SoftwareStatement extends SapiJwt {
             this.orgName = claimsSet.getStringClaim(trustedDirectory.getSoftwareStatementOrgNameClaimName());
             this.softwareId = claimsSet.getStringClaim(trustedDirectory.getSoftwareStatementSoftwareIdClaimName());
             this.clientName = claimsSet.getStringClaim(trustedDirectory.getSoftwareStatementClientNameClaimName());
-            this.trustedDirectoryJwksUrl = trustedDirectory.getDirectoryJwksUri();
+            this.trustedDirectoryJwksUri = trustedDirectory.getDirectoryJwksUri();
             this.redirectUris = claimsSet.getRequiredUriListClaim(trustedDirectory.getSoftwareStatementRedirectUrisClaimName());
             this.roles = claimsSet.getRequiredStringListClaim(trustedDirectory.getSoftwareStatementRolesClaimName());
         }

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/sigvalidation/JwksSupplierJwksUri.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/sigvalidation/JwksSupplierJwksUri.java
@@ -15,7 +15,7 @@
  */
 package com.forgerock.sapi.gateway.dcr.sigvalidation;
 
-import java.net.URL;
+import java.net.URI;
 
 import org.forgerock.json.jose.exceptions.FailedToLoadJWKException;
 import org.forgerock.json.jose.jwk.JWKSet;
@@ -46,7 +46,7 @@ public class JwksSupplierJwksUri implements JwksSupplier {
     @Override
     public Promise<JWKSet, FailedToLoadJWKException> getJWKSet(RegistrationRequest registrationRequest) {
             SoftwareStatement softwareStatement = registrationRequest.getSoftwareStatement();
-            URL softwareStatementsJwksUri = softwareStatement.getJwksUri();
+            URI softwareStatementsJwksUri = softwareStatement.getJwksUri();
             log.debug("Using the jwkSetService to obtain a JWKSet from '{}'", softwareStatementsJwksUri);
             return jwkSetService.getJwkSet(softwareStatementsJwksUri);
     }

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/jwks/DefaultApiClientJwkSetService.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/jwks/DefaultApiClientJwkSetService.java
@@ -15,8 +15,6 @@
  */
 package com.forgerock.sapi.gateway.jwks;
 
-import java.net.MalformedURLException;
-
 import org.forgerock.json.JsonException;
 import org.forgerock.json.JsonValue;
 import org.forgerock.json.jose.exceptions.FailedToLoadJWKException;
@@ -30,7 +28,7 @@ import com.forgerock.sapi.gateway.trusteddirectories.TrustedDirectory;
 
 /**
  * Service which retrieves the JWKSet for an ApiClient.
- *
+ * <p>
  * Determines where to get the JWKSet from based on the TrustedDirectory configuration.
  * - If the directory is configured to contain the JWKS in the SSA then it is fetched from here
  * - Otherwise we expect a jwks_uri to be configured, in which case a {@link JwkSetService} is used to obtain the JWKSet
@@ -38,7 +36,7 @@ import com.forgerock.sapi.gateway.trusteddirectories.TrustedDirectory;
 public class DefaultApiClientJwkSetService implements ApiClientJwkSetService {
 
     /**
-     * The service to delegate to when looking up remote JWKSets by URL
+     * The service to delegate to when looking up remote JWKSets by URI
      */
     private final JwkSetService jwkSetService;
 
@@ -48,7 +46,7 @@ public class DefaultApiClientJwkSetService implements ApiClientJwkSetService {
     }
 
     /**
-     * The JWKSet for an ApiClient can either be looked up via a URL or it is embedded into the software statement,
+     * The JWKSet for an ApiClient can either be looked up via a URI or it is embedded into the software statement,
      * use the TrustedDirectory configuration to determine the location of the JWKSet.
      */
     public Promise<JWKSet, FailedToLoadJWKException> getJwkSet(ApiClient apiClient, TrustedDirectory trustedDirectory) {
@@ -65,15 +63,11 @@ public class DefaultApiClientJwkSetService implements ApiClientJwkSetService {
      * Use the jwkSetService to fetch the JWKSet using the ApiClient.jwksUri
      */
     private Promise<JWKSet, FailedToLoadJWKException> getJwkSetUsingJwksUri(ApiClient apiClient) {
-        try {
-            if (apiClient.getJwksUri() == null) {
-                return Promises.newExceptionPromise(new FailedToLoadJWKException("TrustedDirectory configuration " +
-                        "requires the jwksUri to be set for the apiClient"));
-            }
-            return jwkSetService.getJwkSet(apiClient.getJwksUri().toURL());
-        } catch (MalformedURLException e) {
-            return Promises.newExceptionPromise(new FailedToLoadJWKException("Malformed jwksUri", e));
+        if (apiClient.getJwksUri() == null) {
+            return Promises.newExceptionPromise(new FailedToLoadJWKException("TrustedDirectory configuration " +
+                    "requires the jwksUri to be set for the apiClient"));
         }
+        return jwkSetService.getJwkSet(apiClient.getJwksUri());
     }
 
     /**

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/jwks/JwkSetService.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/jwks/JwkSetService.java
@@ -15,7 +15,7 @@
  */
 package com.forgerock.sapi.gateway.jwks;
 
-import java.net.URL;
+import java.net.URI;
 
 import org.forgerock.json.jose.exceptions.FailedToLoadJWKException;
 import org.forgerock.json.jose.jwk.JWK;
@@ -47,20 +47,20 @@ public interface JwkSetService {
     }
 
     /**
-     * Retrieves a JWKSet for the specified url
+     * Retrieves a JWKSet for the specified uri
      *
-     * @param jwkStoreUrl - url of the JWKSet store
+     * @param jwkSetUri uri used to locate the JWKSet
      * @return Promise which either returns a non-null JWKSet or fails with a FailedToLoadJWKException
      */
-    Promise<JWKSet, FailedToLoadJWKException> getJwkSet(URL jwkStoreUrl);
+    Promise<JWKSet, FailedToLoadJWKException> getJwkSet(URI jwkSetUri);
 
     /**
-     * Retrieves a JWK with the specified keyId from the JWKSet at the specified url.
+     * Retrieves a JWK with the specified keyId from the JWKSet at the specified uri.
      *
-     * @param jwkStoreUrl - url of the JWKSet store
-     * @param keyId - the id (kid) of the JWK within the store to return
+     * @param jwkSetUri uri used to locate the JWKSet
+     * @param keyId the id (kid) of the JWK within the store to return
      * @return Promise which either returns a non-null JWK or fails with a FailedToLoadJWKException
      */
-    Promise<JWK, FailedToLoadJWKException> getJwk(URL jwkStoreUrl, String keyId);
+    Promise<JWK, FailedToLoadJWKException> getJwk(URI jwkSetUri, String keyId);
 
 }

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/jwks/cache/caffeine/CaffeineCachingJwkSetService.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/jwks/cache/caffeine/CaffeineCachingJwkSetService.java
@@ -15,7 +15,7 @@
  */
 package com.forgerock.sapi.gateway.jwks.cache.caffeine;
 
-import java.net.URL;
+import java.net.URI;
 
 import org.forgerock.json.jose.jwk.JWKSet;
 
@@ -27,7 +27,7 @@ import com.forgerock.sapi.gateway.jwks.cache.CachingJwkSetService;
  * This class is required in order to be able to create an instance via IG config.
  */
 public class CaffeineCachingJwkSetService extends CachingJwkSetService {
-    public CaffeineCachingJwkSetService(JwkSetService underlyingStore, CaffeineCache<URL, JWKSet> jwkSetCache) {
+    public CaffeineCachingJwkSetService(JwkSetService underlyingStore, CaffeineCache<URI, JWKSet> jwkSetCache) {
         super(underlyingStore, jwkSetCache);
     }
 }

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/jwks/cache/caffeine/CaffeineCachingJwkSetServiceHeaplet.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/jwks/cache/caffeine/CaffeineCachingJwkSetServiceHeaplet.java
@@ -17,7 +17,7 @@ package com.forgerock.sapi.gateway.jwks.cache.caffeine;
 
 import static org.forgerock.openig.util.JsonValues.javaDuration;
 
-import java.net.URL;
+import java.net.URI;
 import java.time.Duration;
 
 import org.forgerock.json.jose.jwk.JWKSet;
@@ -33,8 +33,8 @@ import com.forgerock.sapi.gateway.jwks.cache.caffeine.CaffeineCache.CacheOptions
 /**
  * Creates a {@link CachingJwkSetService} which is backed by a {@link CaffeineCache}
  * <p>
- * Delegates to {@link RestJwkSetServiceHeaplet} to create the {@link RestJwkSetService}, configuration for RestJwkSetService
- * will be honoured.
+ * Delegates to {@link RestJwkSetServiceHeaplet} to create the {@link RestJwkSetService}, configuration for
+ * RestJwkSetService will be honoured.
  */
 public class CaffeineCachingJwkSetServiceHeaplet extends RestJwkSetServiceHeaplet {
 
@@ -51,17 +51,19 @@ public class CaffeineCachingJwkSetServiceHeaplet extends RestJwkSetServiceHeaple
         return new CachingJwkSetService(restJwkSetService, createCaffeineCache());
     }
 
-    private CaffeineCache<URL, JWKSet> createCaffeineCache() {
+    private CaffeineCache<URI, JWKSet> createCaffeineCache() {
         final long maxCacheEntries = config.get("maxCacheEntries")
-                .as(evaluatedWithHeapProperties())
-                .defaultTo(DEFAULT_MAX_CACHE_SIZE)
-                .asLong();
+                                           .as(evaluatedWithHeapProperties())
+                                           .defaultTo(DEFAULT_MAX_CACHE_SIZE)
+                                           .asLong();
+
         final Duration expireAfterWrite = config.get("expireAfterWriteDuration")
-                .as(evaluatedWithHeapProperties())
-                .defaultTo(DEFAULT_EXPIRE_AFTER_WRITE_DURATION)
-                .as(javaDuration());
+                                                .as(evaluatedWithHeapProperties())
+                                                .defaultTo(DEFAULT_EXPIRE_AFTER_WRITE_DURATION)
+                                                .as(javaDuration());
+
         final CacheOptions options = new CacheOptions().maximumCacheEntries(maxCacheEntries)
-                .expireAfterWrite(expireAfterWrite);
+                                                       .expireAfterWrite(expireAfterWrite);
         logger.info("Creating a cache with options: {}", options);
         return new CaffeineCache<>(options);
     }

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectory.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectory.java
@@ -15,7 +15,7 @@
  */
 package com.forgerock.sapi.gateway.trusteddirectories;
 
-import java.net.URL;
+import java.net.URI;
 
 /**
  * A Trusted Directory is an external 'trust anchor' that the Secure API Gateway should trust to be the issuer
@@ -37,10 +37,10 @@ public interface TrustedDirectory {
 
     /**
      *
-     * @return a String containing the jwks_uri against which software statement issued by this trusted directory
+     * @return a URI containing the jwks_uri against which software statement issued by this trusted directory
      * can be validated
      */
-    URL getDirectoryJwksUri();
+    URI getDirectoryJwksUri();
 
     /**
      * The software statement has a JWKS associated with it which contains the keys belonging to the particular software

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryOpenBankingTest.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryOpenBankingTest.java
@@ -15,8 +15,7 @@
  */
 package com.forgerock.sapi.gateway.trusteddirectories;
 
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
 
 public class TrustedDirectoryOpenBankingTest implements TrustedDirectory {
 
@@ -30,10 +29,10 @@ public class TrustedDirectoryOpenBankingTest implements TrustedDirectory {
     final static boolean softwareStatementHoldsJwksUri = true;
 
     /*
-     * The URL at which the Open Banking Test Directory JWKS are held, containing public certificates that may be used
+     * The URI at which the Open Banking Test Directory JWKS are held, containing public certificates that may be used
      * to validate Open Banking Test directory issues Software Statements.
      */
-    final static URL jwksUri;
+    final static URI jwksUri = URI.create("https://keystore.openbankingtest.org.uk/keystore/openbanking.jwks");
 
     /*
      * The name of the claim in the Open Banking Test Directory issued software statement that holds the jwks_uri
@@ -62,21 +61,13 @@ public class TrustedDirectoryOpenBankingTest implements TrustedDirectory {
 
     static final String softwareStatementClientNameClaimName = "software_client_name";
 
-    static {
-        try {
-            jwksUri = new URL("https://keystore.openbankingtest.org.uk/keystore/openbanking.jwks");
-        } catch (MalformedURLException e) {
-            throw new IllegalArgumentException(e);
-        }
-    }
-
     @Override
     public String getIssuer() {
         return issuer;
     }
 
     @Override
-    public URL getDirectoryJwksUri() {
+    public URI getDirectoryJwksUri() {
         return jwksUri;
     }
 

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectorySecureApiGateway.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectorySecureApiGateway.java
@@ -15,7 +15,7 @@
  */
 package com.forgerock.sapi.gateway.trusteddirectories;
 
-import java.net.URL;
+import java.net.URI;
 
 /**
  * Holds static configuration information for the Trusted Directory provided by the Secure API Gateway itself. For
@@ -31,10 +31,10 @@ public class TrustedDirectorySecureApiGateway implements TrustedDirectory {
     final static String issuer = "test-publisher";
 
     /*
-     * The URL at which the Open Banking Test Directory JWKS are held, containing public certificates that may be used
+     * The URI at which the Open Banking Test Directory JWKS are held, containing public certificates that may be used
      * to validate Open Banking Test directory issues Software Statements.
      */
-    URL secureApiGatewayJwksUri = null;
+    URI secureApiGatewayJwksUri = null;
 
     final static boolean softwareStatementHoldsJwksUri = false;
 
@@ -68,7 +68,7 @@ public class TrustedDirectorySecureApiGateway implements TrustedDirectory {
      * @param secureApiGatewayJwksUri The jwks_uri against which SSAs issued by the Secure API Gateway can be
      *                                validated
      */
-    public TrustedDirectorySecureApiGateway(URL secureApiGatewayJwksUri){
+    public TrustedDirectorySecureApiGateway(URI secureApiGatewayJwksUri){
         this.secureApiGatewayJwksUri = secureApiGatewayJwksUri;
     }
 
@@ -78,7 +78,7 @@ public class TrustedDirectorySecureApiGateway implements TrustedDirectory {
     }
 
     @Override
-    public URL getDirectoryJwksUri() {
+    public URI getDirectoryJwksUri() {
         return this.secureApiGatewayJwksUri;
     }
 

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryServiceHeaplet.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryServiceHeaplet.java
@@ -15,18 +15,13 @@
  */
 package com.forgerock.sapi.gateway.trusteddirectories;
 
-import static org.forgerock.openig.util.JsonValues.javaDuration;
-
 import java.net.MalformedURLException;
-import java.net.URL;
-import java.time.Duration;
+import java.net.URI;
 
 import org.forgerock.openig.heap.GenericHeaplet;
 import org.forgerock.openig.heap.HeapException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.forgerock.sapi.gateway.jwks.cache.caffeine.CaffeineCache;
 
 public class TrustedDirectoryServiceHeaplet extends GenericHeaplet {
 
@@ -53,10 +48,8 @@ public class TrustedDirectoryServiceHeaplet extends GenericHeaplet {
                 .defaultTo(null)
                 .asString();
 
-
         logger.debug("Creating Trusted Directory Service with enableIGTestTrustedDirectory: {}, secureApiGatewayJwksUri: {}",
                 enableIGTestTrustedDirectory, secureApiGatewayJwksUri);
-        URL secureApiGatewayJwksUrl = new URL(secureApiGatewayJwksUri);
-        return new TrustedDirectoryServiceStatic(enableIGTestTrustedDirectory, secureApiGatewayJwksUrl);
+        return new TrustedDirectoryServiceStatic(enableIGTestTrustedDirectory, URI.create(secureApiGatewayJwksUri));
     }
 }

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryServiceStatic.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryServiceStatic.java
@@ -15,7 +15,7 @@
  */
 package com.forgerock.sapi.gateway.trusteddirectories;
 
-import java.net.URL;
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -40,7 +40,7 @@ public class TrustedDirectoryServiceStatic implements TrustedDirectoryService {
      * @param secureApiGatewayJwksUri The jwks_uri against which the signature of SSAs issued by the Trusted Directory
      *                                may be validated
      */
-    public TrustedDirectoryServiceStatic(Boolean enableIGTestTrustedDirectory, URL secureApiGatewayJwksUri) {
+    public TrustedDirectoryServiceStatic(Boolean enableIGTestTrustedDirectory, URI secureApiGatewayJwksUri) {
         directoryConfigurations = new HashMap<>();
 
         addOpenBankingTestTrustedDirectory();
@@ -61,7 +61,7 @@ public class TrustedDirectoryServiceStatic implements TrustedDirectoryService {
         return directoryConfigurations.get(issuer);
     }
 
-    private void addGatewayTestTrustedDirectory(URL testDirectoryFQDN) {
+    private void addGatewayTestTrustedDirectory(URI testDirectoryFQDN) {
         TrustedDirectory secureApiGatewayTrustedDirectory = new TrustedDirectorySecureApiGateway(testDirectoryFQDN);
         directoryConfigurations.put(secureApiGatewayTrustedDirectory.getIssuer(), secureApiGatewayTrustedDirectory);
     }

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/common/jwt/ClaimsSetFacadeTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/common/jwt/ClaimsSetFacadeTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.catchThrowableOfType;
 
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
@@ -87,7 +88,7 @@ class ClaimsSetFacadeTest {
     void success_getStringClaimAsURL() throws JwtException {
         // Given
         // When
-        URL claimValue = claimSet.getStringClaimAsURL("jwks_uri");
+        URI claimValue = claimSet.getStringClaimAsURI("jwks_uri");
         // Then
         assertThat(claimValue).isNotNull();
     }
@@ -96,7 +97,7 @@ class ClaimsSetFacadeTest {
     void throwsWhenClaimNotUrl_getStringClaimAsURL() {
         // Given
         // When
-        JwtException exception = catchThrowableOfType(() ->claimSet.getStringClaimAsURL("claim1"), JwtException.class);
+        JwtException exception = catchThrowableOfType(() ->claimSet.getStringClaimAsURI("@~}~@}"), JwtException.class);
         // Then
         assertThat(exception).isNotNull();
     }
@@ -105,7 +106,7 @@ class ClaimsSetFacadeTest {
     void throwsWhenClaimDoesNotExist_getStringClaimAsURL() {
         // Given
         // When
-        JwtException exception = catchThrowableOfType(() ->claimSet.getStringClaimAsURL("nonexistant"), JwtException.class);
+        JwtException exception = catchThrowableOfType(() ->claimSet.getStringClaimAsURI("nonexistant"), JwtException.class);
         // Then
         assertThat(exception).isNotNull();
     }
@@ -114,7 +115,7 @@ class ClaimsSetFacadeTest {
     void throwsWhenInvalidArgument_getStringClaimAsURL() {
         // Given
         // When
-        IllegalArgumentException exception = catchThrowableOfType(() ->claimSet.getStringClaimAsURL(""),
+        IllegalArgumentException exception = catchThrowableOfType(() ->claimSet.getStringClaimAsURI(""),
                 IllegalArgumentException.class);
         // Then
         assertThat(exception).isNotNull();
@@ -130,7 +131,7 @@ class ClaimsSetFacadeTest {
     }
 
     @Test
-    void throwsWhenClaimDoesNotExist_getJsonValueClaim() throws JwtException {
+    void throwsWhenClaimDoesNotExist_getJsonValueClaim() {
         // Given
         // When
         JwtException exception  = catchThrowableOfType(()->claimSet.getJsonValueClaim("nonExistent"), JwtException.class);
@@ -139,7 +140,7 @@ class ClaimsSetFacadeTest {
     }
 
     @Test
-    void throwsWhenInvalidArgument_getJsonValueClaim() throws JwtException {
+    void throwsWhenInvalidArgument_getJsonValueClaim() {
         // Given
         // When
         IllegalArgumentException exception  = catchThrowableOfType(()->claimSet.getJsonValueClaim(""),
@@ -294,7 +295,7 @@ class ClaimsSetFacadeTest {
         ClaimsSetFacade claimsSetFacade = new ClaimsSetFacade(claimsSet);
 
         // When
-        List<URL> responseTypes =  claimsSetFacade.getRequiredUriListClaim("response_type");
+        List<URI> responseTypes =  claimsSetFacade.getRequiredUriListClaim("response_type");
 
         // Then
         assertThat(responseTypes).isNotNull();
@@ -306,7 +307,7 @@ class ClaimsSetFacadeTest {
     void fail_getRequiredUriList_NotURLs() {
 
         // Given
-        JwtClaimsSet claimsSet = new JwtClaimsSet(Map.of("response_type", List.of("hello", "there")));
+        JwtClaimsSet claimsSet = new JwtClaimsSet(Map.of("response_type", List.of("@~}[hello", "there")));
         ClaimsSetFacade claimsSetFacade = new ClaimsSetFacade(claimsSet);
 
         // When
@@ -315,7 +316,7 @@ class ClaimsSetFacadeTest {
 
         // Then
         assertThat(exception).isNotNull();
-        assertThat(exception.getMessage()).contains("claim of name 'response_type' is expected to hold valid URLs:");
+        assertThat(exception.getMessage()).contains("claim of name 'response_type' is expected to hold valid URIs:");
     }
 
     @Test

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/models/SoftwareStatementBuilderTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/models/SoftwareStatementBuilderTest.java
@@ -18,8 +18,8 @@ package com.forgerock.sapi.gateway.dcr.models;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.catchThrowableOfType;
 
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Map;
 
 import org.forgerock.json.jose.jwk.JWKSet;
@@ -58,7 +58,7 @@ class SoftwareStatementBuilderTest {
 
     @Test
     void successJwksUriBased_buildSoftwareStatement()
-            throws DCRRegistrationRequestBuilderException, MalformedURLException {
+            throws DCRRegistrationRequestBuilderException, URISyntaxException {
         // Given
         Map<String, Object> ssaClaims = SoftwareStatementTestFactory.getValidJwksUriBasedSsaClaims(Map.of());
         String requestJwt = CryptoUtils.createEncodedJwtString(ssaClaims, JWSAlgorithm.PS256);
@@ -73,7 +73,7 @@ class SoftwareStatementBuilderTest {
         assertThat(softwareStatement.getSoftwareId()).isEqualTo(SOFTWARE_ID);
         assertThat(softwareStatement.getClientName()).isEqualTo(SOFTWARE_CLIENT_NAME);
         assertThat(softwareStatement.hasJwksUri()).isTrue();
-        assertThat(softwareStatement.getJwksUri()).isEqualTo(new URL(JWKS_URI));
+        assertThat(softwareStatement.getJwksUri()).isEqualTo(new URI(JWKS_URI));
     }
 
     @Test

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/service/idm/IdmApiClientServiceTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/service/idm/IdmApiClientServiceTest.java
@@ -29,7 +29,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.LinkedHashMap;
@@ -229,11 +228,7 @@ public class IdmApiClientServiceTest {
 
         if (createApiClientJson.get("jwksUri").isNotNull()) {
             when(softwareStatement.hasJwksUri()).thenReturn(true);
-            try {
-                when(softwareStatement.getJwksUri()).thenReturn(URI.create(createApiClientJson.get("jwksUri").asString()).toURL());
-            } catch (MalformedURLException e) {
-                throw new RuntimeException(e);
-            }
+            when(softwareStatement.getJwksUri()).thenReturn(URI.create(createApiClientJson.get("jwksUri").asString()));
         }
         else if (createApiClientJson.get("jwks").isNotNull()) {
             when(softwareStatement.hasJwksUri()).thenReturn(false);

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/sigvalidation/JwksSupplierJwksUriTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/sigvalidation/JwksSupplierJwksUriTest.java
@@ -21,8 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
 
 import org.forgerock.json.jose.exceptions.FailedToLoadJWKException;
 import org.forgerock.json.jose.jwk.JWKSet;
@@ -56,12 +55,11 @@ class JwksSupplierJwksUriTest {
     }
 
     @Test
-    void failsCantGetJwksSetFromUri_getJwks() throws MalformedURLException {
+    void failsCantGetJwksSetFromUri_getJwks() {
         // Given
-        final String JWKS_URI = "https://jwks_uri.com";
-        final URL JWKS_URL = new URL(JWKS_URI);
-        when(softwareStatement.getJwksUri()).thenReturn(JWKS_URL);
-        when(jwkSetService.getJwkSet(JWKS_URL)).thenReturn(
+        final URI jwksUri = URI.create("https://jwks_uri.com");
+        when(softwareStatement.getJwksUri()).thenReturn(jwksUri);
+        when(jwkSetService.getJwkSet(jwksUri)).thenReturn(
                 Promises.newExceptionPromise(new FailedToLoadJWKException("Couldn't load JWKS")));
 
         // When
@@ -77,13 +75,12 @@ class JwksSupplierJwksUriTest {
 
 
     @Test
-    void success_getJWKSet() throws InterruptedException, MalformedURLException, FailedToLoadJWKException {
+    void success_getJWKSet() throws InterruptedException, FailedToLoadJWKException {
         // Given
-        final String JWKS_URI = "https://jwks_uri.com";
-        final URL JWKS_URL = new URL(JWKS_URI);
-        when(softwareStatement.getJwksUri()).thenReturn(JWKS_URL);
+        final URI jwksUri = URI.create("https://jwks_uri.com");
+        when(softwareStatement.getJwksUri()).thenReturn(jwksUri);
         JWKSet jwks = new JWKSet();
-        when(jwkSetService.getJwkSet(JWKS_URL)).thenReturn(Promises.newResultPromise(jwks));
+        when(jwkSetService.getJwkSet(jwksUri)).thenReturn(Promises.newResultPromise(jwks));
 
         // When
         Promise<JWKSet, FailedToLoadJWKException> promise =

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/sigvalidation/RegistrationRequestJwtSignatureValidationServiceTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/sigvalidation/RegistrationRequestJwtSignatureValidationServiceTest.java
@@ -27,8 +27,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
 import java.security.SignatureException;
 import java.util.concurrent.ExecutionException;
 
@@ -93,12 +92,12 @@ class RegistrationRequestJwtSignatureValidationServiceTest {
     }
 
     @Test
-    void failsToLoadJwksFromJwksUri_withJwksUri_validateJwtSignature() throws SignatureException, MalformedURLException {
+    void failsToLoadJwksFromJwksUri_withJwksUri_validateJwtSignature() throws SignatureException {
         // Given
         JWKSet jwkSet = new JWKSet();
         SignedJwt signedJwt = mock(SignedJwt.class);
         when(softwareStatement.hasJwksUri()).thenReturn(true);
-        when(softwareStatement.getJwksUri()).thenReturn(new URL("https://jwks.com"));
+        when(softwareStatement.getJwksUri()).thenReturn(URI.create("https://jwks.com"));
         when(jwksFromJwksUriSupplier.getJWKSet(eq(registrationRequest))).thenReturn(Promises.newExceptionPromise(
                         new FailedToLoadJWKException("Failed to load jwks")));
         doThrow(new SignatureException("invalid jwt signature")).when(jwtSignatureValidator).validateSignature(signedJwt, jwkSet);
@@ -114,12 +113,12 @@ class RegistrationRequestJwtSignatureValidationServiceTest {
     }
 
     @Test
-    void failsInvalidJwtSignature_withJwksUri_validateJwtSignature() throws SignatureException, MalformedURLException {
+    void failsInvalidJwtSignature_withJwksUri_validateJwtSignature() throws SignatureException {
         // Given
         JWKSet jwkSet = new JWKSet();
         SignedJwt signedJwt = mock(SignedJwt.class);
         when(softwareStatement.hasJwksUri()).thenReturn(true);
-        when(softwareStatement.getJwksUri()).thenReturn(new URL("https://jwks.com"));
+        when(softwareStatement.getJwksUri()).thenReturn(URI.create("https://jwks.com"));
         when(jwksFromJwksUriSupplier.getJWKSet(eq(registrationRequest)))
                 .thenReturn(Promises.newResultPromise(jwkSet));
         when(registrationRequest.getSignedJwt()).thenReturn(signedJwt);

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/sigvalidation/SoftwareStatementAssertionSignatureValidatorServiceTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/sigvalidation/SoftwareStatementAssertionSignatureValidatorServiceTest.java
@@ -22,8 +22,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
 import java.security.SignatureException;
 import java.util.Map;
 
@@ -67,20 +66,17 @@ class SoftwareStatementAssertionSignatureValidatorServiceTest {
     void failIfSignatureInvalid_validateSoftwareStatementAssertionSignature() throws Exception {
         // Given
         SignedJwt ssaSignedJwt = CryptoUtils.createSignedJwt(Map.of("iss", SSA_ISSUER),
-                JWSAlgorithm.PS256);
-        final String JWK_SET_URL_STR = "https://jwkset.com";
-        final URL JWK_SET_URL = new URL(JWK_SET_URL_STR);
-        final JWKSet JWKS_SET = new JWKSet();
-
+                                                             JWSAlgorithm.PS256);
+        final URI jwksUri = URI.create("https://jwkset.com");
+        final JWKSet jwkSet = new JWKSet();
 
         // When
-        when(softwareStatement.getTrustedDirectoryJwksUrl()).thenReturn(JWK_SET_URL);
+        when(softwareStatement.getTrustedDirectoryJwksUri()).thenReturn(jwksUri);
         when(softwareStatement.getSignedJwt()).thenReturn(ssaSignedJwt);
-        when(softwareStatement.getJwksSet()).thenReturn(JWKS_SET);
-        when(jwkSetService.getJwkSet(JWK_SET_URL)).thenReturn(
-                Promises.newResultPromise(JWKS_SET));
+        when(softwareStatement.getJwksSet()).thenReturn(jwkSet);
+        when(jwkSetService.getJwkSet(jwksUri)).thenReturn(Promises.newResultPromise(jwkSet));
         doThrow(new SignatureException("Invalid sig")).when(jwtSignatureValidator)
-                .validateSignature(ssaSignedJwt, JWKS_SET);
+                .validateSignature(ssaSignedJwt, jwkSet);
 
         Promise<Response, DCRSignatureValidationException> promise =
                 ssaSigValidator.validateJwtSignature(softwareStatement);
@@ -92,20 +88,17 @@ class SoftwareStatementAssertionSignatureValidatorServiceTest {
     }
 
     @Test
-    void success_validateSoftwareStatementAssertionSignature()
-            throws MalformedURLException, InterruptedException, DCRSignatureValidationException {
+    void success_validateSoftwareStatementAssertionSignature() throws InterruptedException, DCRSignatureValidationException {
         // Given
         SignedJwt ssaSignedJwt = CryptoUtils.createSignedJwt(Map.of("iss", SSA_ISSUER),
-                JWSAlgorithm.PS256);
-        final String JWK_SET_URL_STR = "https://jwkset.com";
-        final URL JWK_SET_URL = new URL(JWK_SET_URL_STR);
-        final JWKSet JWKS_SET = new JWKSet();
+                                                            JWSAlgorithm.PS256);
+        final URI jwksUri = URI.create("https://jwkset.com");
+        final JWKSet jwkSet = new JWKSet();
 
         // When
-        when(softwareStatement.getTrustedDirectoryJwksUrl()).thenReturn(JWK_SET_URL);
+        when(softwareStatement.getTrustedDirectoryJwksUri()).thenReturn(jwksUri);
         when(softwareStatement.getSignedJwt()).thenReturn(ssaSignedJwt);
-        when(jwkSetService.getJwkSet(JWK_SET_URL)).thenReturn(
-                Promises.newResultPromise(JWKS_SET));
+        when(jwkSetService.getJwkSet(jwksUri)).thenReturn(Promises.newResultPromise(jwkSet));
 
         Promise<Response, DCRSignatureValidationException> promise =
                 ssaSigValidator.validateJwtSignature(softwareStatement);

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/jwks/FetchApiClientJwksFilterTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/jwks/FetchApiClientJwksFilterTest.java
@@ -25,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.net.URL;
+import java.net.URI;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -49,9 +49,9 @@ import org.forgerock.util.promise.Promises;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import com.forgerock.sapi.gateway.dcr.models.ApiClientTest;
 import com.forgerock.sapi.gateway.dcr.filter.FetchApiClientFilter;
 import com.forgerock.sapi.gateway.dcr.models.ApiClient;
+import com.forgerock.sapi.gateway.dcr.models.ApiClientTest;
 import com.forgerock.sapi.gateway.jwks.FetchApiClientJwksFilter.Heaplet;
 import com.forgerock.sapi.gateway.jwks.mocks.MockJwkSetService;
 import com.forgerock.sapi.gateway.trusteddirectories.FetchTrustedDirectoryFilter;
@@ -134,8 +134,8 @@ class FetchApiClientJwksFilterTest {
         @Test
         void successfullyCreatesFilter() throws Exception {
             final JWKSet jwkSet = createJwkSet();
-            final URL jwksUri = new URL("https://directory.com/jwks/12345");
-            final MockJwkSetService jwkSetService = new MockJwkSetService(Map.of(jwksUri, jwkSet));
+            final URI jwkSetUri = URI.create("https://directory.com/jwks/12345");
+            final MockJwkSetService jwkSetService = new MockJwkSetService(Map.of(jwkSetUri, jwkSet));
 
             final HeapImpl heap = new HeapImpl(Name.of("heap"));
             heap.put("JwkSetService", jwkSetService);
@@ -144,7 +144,7 @@ class FetchApiClientJwksFilterTest {
             final FetchApiClientJwksFilter filter = (FetchApiClientJwksFilter) new Heaplet().create(Name.of("test"), config, heap);
 
             final Context context = new AttributesContext(new RootContext());
-            addApiClientToContext(context, createApiClientWithJwksUri(jwksUri.toURI()));
+            addApiClientToContext(context, createApiClientWithJwksUri(jwkSetUri));
             addTrustedDirectoryToContext(context, new TrustedDirectoryOpenBankingTest());
             final TestSuccessResponseHandler responseHandler = new TestSuccessResponseHandler();
             final Promise<Response, NeverThrowsException> responsePromise = filter.filter(context, new Request(), responseHandler);

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/jwks/cache/CachingJwkSetServiceTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/jwks/cache/CachingJwkSetServiceTest.java
@@ -15,7 +15,7 @@
  */
 package com.forgerock.sapi.gateway.jwks.cache;
 
-import java.net.URL;
+import java.net.URI;
 
 import org.forgerock.json.jose.jwk.JWKSet;
 
@@ -24,7 +24,7 @@ import org.forgerock.json.jose.jwk.JWKSet;
  */
 public class CachingJwkSetServiceTest extends BaseCachingJwkSetServiceTest {
     @Override
-    protected Cache<URL, JWKSet> createSimpleCache() {
+    protected Cache<URI, JWKSet> createSimpleCache() {
         return new HashMapCache<>();
     }
 }

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/jwks/mocks/MockJwkSetService.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/jwks/mocks/MockJwkSetService.java
@@ -15,8 +15,7 @@
  */
 package com.forgerock.sapi.gateway.jwks.mocks;
 
-import java.net.URL;
-import java.util.Collection;
+import java.net.URI;
 import java.util.Map;
 
 import org.forgerock.json.jose.exceptions.FailedToLoadJWKException;
@@ -31,18 +30,19 @@ import com.forgerock.sapi.gateway.jwks.cache.BaseCachingJwkSetServiceTest;
  * Returns an error if getJwkSet is called with a different url, or i getJwk is called.
  */
 public class MockJwkSetService extends BaseCachingJwkSetServiceTest.BaseCachingTestJwkSetService {
-    private final Map<URL, JWKSet> jwkSetsByUrl;
+    private final Map<URI, JWKSet> jwkSetsByUri;
 
-    public MockJwkSetService(Map<URL, JWKSet> jwkSetsByURL) {
-        this.jwkSetsByUrl = jwkSetsByURL;
+    public MockJwkSetService(Map<URI, JWKSet> jwkSetsByURL) {
+        this.jwkSetsByUri = jwkSetsByURL;
     }
 
     @Override
-    public Promise<JWKSet, FailedToLoadJWKException> getJwkSet(URL jwkStoreUrl) {
-        if (jwkSetsByUrl.containsKey(jwkStoreUrl)) {
-            return Promises.newResultPromise(jwkSetsByUrl.get(jwkStoreUrl));
+    public Promise<JWKSet, FailedToLoadJWKException> getJwkSet(URI jwkStoreUri) {
+        if (jwkSetsByUri.containsKey(jwkStoreUri)) {
+            return Promises.newResultPromise(jwkSetsByUri.get(jwkStoreUri));
         }
-        return Promises.newExceptionPromise(new FailedToLoadJWKException("actual jwkStoreUrl: " + jwkStoreUrl
-                + ", does not match expected: " + jwkSetsByUrl.keySet()));
+        return Promises.newExceptionPromise(new FailedToLoadJWKException("actual jwkStoreUrl: " + jwkStoreUri
+                + ", does not match expected: " + jwkSetsByUri.keySet()));
+
     }
 }

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/mtls/TokenEndpointTransportCertValidationFilterTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/mtls/TokenEndpointTransportCertValidationFilterTest.java
@@ -33,7 +33,6 @@ import static org.mockito.Mockito.mock;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.Map;
@@ -60,10 +59,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import com.forgerock.sapi.gateway.dcr.service.ApiClientService;
-import com.forgerock.sapi.gateway.dcr.models.ApiClientTest;
 import com.forgerock.sapi.gateway.dcr.filter.FetchApiClientFilter;
 import com.forgerock.sapi.gateway.dcr.models.ApiClient;
+import com.forgerock.sapi.gateway.dcr.models.ApiClientTest;
+import com.forgerock.sapi.gateway.dcr.service.ApiClientService;
 import com.forgerock.sapi.gateway.dcr.service.idm.IdmApiClientServiceTest.MockGetApiClientIdmHandler;
 import com.forgerock.sapi.gateway.jwks.ApiClientJwkSetService;
 import com.forgerock.sapi.gateway.jwks.mocks.MockJwkSetService;
@@ -292,7 +291,7 @@ class TokenEndpointTransportCertValidationFilterTest {
             final Heaplet transportCertValidationFilterHeaplet = new Heaplet();
             final HeapImpl heap = new HeapImpl(Name.of("heap"));
 
-            final URL apiClientJwksUrl = new URL("https://localhost/apiClient.jwks");
+            final URI apiClientJwksUrl = URI.create("https://localhost/apiClient.jwks");
             final JsonValue idmClientData = createIdmApiClientWithJwksUri(testClientId, apiClientJwksUrl.toString());
 
             final String idmBaseUri = "https://localhost/idm/getApiClient";
@@ -334,7 +333,7 @@ class TokenEndpointTransportCertValidationFilterTest {
             final Heaplet transportCertValidationFilterHeaplet = new Heaplet();
             final HeapImpl heap = new HeapImpl(Name.of("heap"));
 
-            final URL apiClientJwksUrl = new URL("https://localhost/apiClient.jwks");
+            final URI apiClientJwksUrl = URI.create("https://localhost/apiClient.jwks");
             final JsonValue idmClientData = createIdmApiClientWithJwksUri(testClientId, apiClientJwksUrl.toString());
 
             final String idmBaseUri = "https://localhost/idm/getApiClient";

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/FetchTrustedDirectoryFilterTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/FetchTrustedDirectoryFilterTest.java
@@ -19,10 +19,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.forgerock.json.JsonValue.field;
 import static org.forgerock.json.JsonValue.json;
 import static org.forgerock.json.JsonValue.object;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
 
 import org.forgerock.http.protocol.Request;
 import org.forgerock.json.JsonValue;
@@ -39,9 +41,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import com.forgerock.sapi.gateway.dcr.models.ApiClientTest;
-import com.forgerock.sapi.gateway.dcr.models.ApiClient;
 import com.forgerock.sapi.gateway.dcr.filter.FetchApiClientFilter;
+import com.forgerock.sapi.gateway.dcr.models.ApiClient;
+import com.forgerock.sapi.gateway.dcr.models.ApiClientTest;
 import com.forgerock.sapi.gateway.trusteddirectories.FetchTrustedDirectoryFilter.Heaplet;
 import com.forgerock.sapi.gateway.util.TestHandlers.TestSuccessResponseHandler;
 
@@ -50,10 +52,9 @@ public class FetchTrustedDirectoryFilterTest {
     private TrustedDirectoryService trustedDirectoryService;
 
     @BeforeEach
-    void setUp() throws MalformedURLException {
-        String secureApiGatewayJwksUri = "https://test-bank.com";
-        URL secureApiGatewayJwksUrl = new URL(secureApiGatewayJwksUri);
-        trustedDirectoryService = new TrustedDirectoryServiceStatic(true, secureApiGatewayJwksUrl);
+    void setUp() {
+        URI secureApiGatewayJwksUri = URI.create("https://test-bank.com");
+        trustedDirectoryService = new TrustedDirectoryServiceStatic(true, secureApiGatewayJwksUri);
     }
 
     public static ApiClient createApiClient(String issuer) {

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryServiceStaticTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryServiceStaticTest.java
@@ -17,8 +17,7 @@ package com.forgerock.sapi.gateway.trusteddirectories;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -27,11 +26,11 @@ import org.junit.jupiter.api.Test;
 
 class TrustedDirectoryServiceStaticTest {
 
-    private static URL testDirectoryFQDN;
+    private static URI testDirectoryFQDN;
 
     @BeforeAll
-    static void setupAll() throws MalformedURLException {
-        testDirectoryFQDN = new URL("https://sapi.bigbank.com/jwkms/testdirectory/jwks");
+    static void setupAll() {
+        testDirectoryFQDN = URI.create("https://sapi.bigbank.com/jwkms/testdirectory/jwks");
     }
 
     @BeforeEach
@@ -43,7 +42,7 @@ class TrustedDirectoryServiceStaticTest {
     }
 
     @Test
-    void getTrustedDirectoryConfiguration_IGTestDirectoryEnabled() throws MalformedURLException {
+    void getTrustedDirectoryConfiguration_IGTestDirectoryEnabled() {
         // Given
         Boolean enableIGTestTrustedDirectory = true;
         TrustedDirectoryService trustedDirectoryService =

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryTestFactory.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/trusteddirectories/TrustedDirectoryTestFactory.java
@@ -15,23 +15,14 @@
  */
 package com.forgerock.sapi.gateway.trusteddirectories;
 
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
 
 public class TrustedDirectoryTestFactory {
 
-    private static URL jwks_uri;
+    private static URI jwks_uri = URI.create("https://jwks_uri.com");
 
     public static String JWKS_BASED_DIRECTORY_ISSUER = "JwksBasedTrustedDirectory";
     public static String JWKS_URI_BASED_DIRECTORY_ISSUER = "JwksUriBasedTrustedDirectory";
-
-    static {
-        try {
-            jwks_uri = new URL("https://jwks_uri.com");
-        } catch (MalformedURLException e) {
-            throw new RuntimeException(e);
-        }
-    }
 
     private static TrustedDirectory jwksUriBasedTrustedDirectory = new TrustedDirectory() {
         @Override
@@ -40,7 +31,7 @@ public class TrustedDirectoryTestFactory {
         }
 
         @Override
-        public URL getDirectoryJwksUri() {
+        public URI getDirectoryJwksUri() {
             return jwks_uri;
         }
 
@@ -97,7 +88,7 @@ public class TrustedDirectoryTestFactory {
         }
 
         @Override
-        public URL getDirectoryJwksUri() {
+        public URI getDirectoryJwksUri() {
             return jwks_uri;
         }
 


### PR DESCRIPTION
URIs are a better choice as the equals method compares the string representation.

URLs on the other hand do DNS lookups to resolve the IP address of the host, and use this value in the equality check, this adds both a performance hit and causes URLs with the same representation not to be equal if the IP address changes (which can be a common scenario when DNS round robin is being used).

This issue with URL equality was causing us to suffer cache misses for the JWKS caching functionality, and caused duplicate entries to be cached.

Changing to use URIs across the codebase for consistency.

Note, URLs were originally chosen to match the public API of the library class: org.forgerock.json.jose.jwk.JWKSetParser

https://github.com/SecureApiGateway/SecureApiGateway/issues/1393