### PR TITLE
1389: Use CI Repo for standardised steps in github workflows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,14 @@ ifndef tag
 	$(warning no tag supplied; latest assumed)
 	$(eval tag=latest)
 endif
-	docker build secure-api-gateway-core-docker -t ${repo}/securebanking/${service}:${tag}
-	docker push ${repo}/securebanking/${service}:${tag}
 
+	if [ "${tag}" = "latest" ]; then \
+		docker build secure-api-gateway-core-docker -t ${repo}/securebanking/${service}:${tag} -t ${repo}/securebanking/${service}:dev; \
+		docker push ${repo}/securebanking/${service} --all-tags; \
+    else \
+   		docker build secure-api-gateway-core-docker -t ${repo}/securebanking/${service}:${tag}; \
+   		docker push ${repo}/securebanking/${service}:${tag}; \
+   	fi;
 conf:
 ifndef env
 	$(warning no env supplied; prod assumed)

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,13 @@ ifndef tag
 	$(warning no tag supplied; latest assumed)
 	$(eval tag=latest)
 endif
+ifndef setlatest
+	$(warning no setlatest true|false supplied; false assumed)
+	$(eval setlatest=false)
+endif
 
-	if [ "${tag}" = "latest" ]; then \
-		docker build secure-api-gateway-core-docker -t ${repo}/securebanking/${service}:${tag} -t ${repo}/securebanking/${service}:dev; \
+	if [ "${setlatest}" = "true" ]; then \
+		docker build secure-api-gateway-core-docker -t ${repo}/securebanking/${service}:${tag} -t ${repo}/securebanking/${service}:latest; \
 		docker push ${repo}/securebanking/${service} --all-tags; \
     else \
    		docker build secure-api-gateway-core-docker -t ${repo}/securebanking/${service}:${tag}; \


### PR DESCRIPTION
Multiple make commands was creating multiple docker images with a single tag, want to have a single docker image with multiple tags

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1389