### PR TITLE
1115: Remove blocking IO call in TokenEndpointMetricsContextSupplier

### DIFF
--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/metrics/MetricsContextSupplier.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/metrics/MetricsContextSupplier.java
@@ -20,6 +20,9 @@ import java.util.Map;
 
 import org.forgerock.http.protocol.Request;
 import org.forgerock.services.context.Context;
+import org.forgerock.util.promise.NeverThrowsException;
+import org.forgerock.util.promise.Promise;
+import org.forgerock.util.promise.Promises;
 
 /**
  * Supplies context data to store in the RouteMetricsEvent.context field.
@@ -32,17 +35,17 @@ public interface MetricsContextSupplier {
      * Implementation which returns an empty context, this can be used for routes which do not have any context
      * information to report.
      */
-    MetricsContextSupplier EMPTY_CONTEXT_SUPPLIER = (requestContext, request) -> Collections.emptyMap();
+    MetricsContextSupplier EMPTY_CONTEXT_SUPPLIER = (requestContext, request) -> Promises.newResultPromise(Collections.emptyMap());
 
     /**
      * Extract Metrics Context information for the given HTTP Request and Request Context.
      *
      * @param requestContext HTTP request's Context which may be used to extract metrics context information from
      * @param request        HTTP request which may be used to extract metrics context information from
-     * @return Map<String, Object> the metrics context information for this request, NOTE: must be serializable to JSON using
-     * the {@link org.forgerock.http.util.Json#writeJson(Object)} method. When there is no context information to report
-     * then an empty Map should be returned.
+     * @return Promise with a Map<String, Object> containing the metrics context information for this request.
+     * NOTE: must be serializable to JSON using the {@link org.forgerock.http.util.Json#writeJson(Object)} method.
+     * When there is no context information to report then an empty Map should be returned.
      */
-    Map<String, Object> getMetricsContext(Context requestContext, Request request);
+    Promise<Map<String, Object>, NeverThrowsException> getMetricsContext(Context requestContext, Request request);
 
 }

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/metrics/RouteMetricsFilter.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/metrics/RouteMetricsFilter.java
@@ -15,8 +15,9 @@
  */
 package com.forgerock.sapi.gateway.metrics;
 
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
 import static org.forgerock.openig.util.JsonValues.optionalHeapObject;
-import static org.forgerock.util.Reject.checkNotNull;
 
 import java.util.Collections;
 import java.util.Map;
@@ -34,6 +35,7 @@ import org.forgerock.openig.heap.HeapException;
 import org.forgerock.services.context.Context;
 import org.forgerock.util.promise.NeverThrowsException;
 import org.forgerock.util.promise.Promise;
+import org.forgerock.util.promise.Promises;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -82,22 +84,23 @@ public class RouteMetricsFilter implements Filter {
     public RouteMetricsFilter(Ticker ticker, LongSupplier timestampSupplier,
                               RouteMetricsEventPublisher metricsEventPublisher,
                               MetricsContextSupplier metricsContextSupplier) {
-        this.ticker = checkNotNull(ticker, "ticker must be provided");
-        this.timestampSupplier = checkNotNull(timestampSupplier, "timestampSupplier must be provided");
-        this.metricsEventPublisher = checkNotNull(metricsEventPublisher, "metricsEventPublisher must be provided");
-        this.metricsContextSupplier = checkNotNull(metricsContextSupplier, "metricsContextSupplier must be provided");
+        this.ticker = requireNonNull(ticker, "ticker must be provided");
+        this.timestampSupplier = requireNonNull(timestampSupplier, "timestampSupplier must be provided");
+        this.metricsEventPublisher = requireNonNull(metricsEventPublisher, "metricsEventPublisher must be provided");
+        this.metricsContextSupplier = requireNonNull(metricsContextSupplier, "metricsContextSupplier must be provided");
     }
 
     @Override
     public Promise<Response, NeverThrowsException> filter(Context context, Request request, Handler handler) {
         final Stopwatch stopwatch = Stopwatch.createStarted(ticker);
-        final Map<String, Object> routeMetricsContext = getRouteMetricsContext(context, request);
-        return handler.handle(context, request).thenOnResult(response -> {
-            try {
-                metricsEventPublisher.publish(buildRouteMetricsEvent(stopwatch, context, request, response, routeMetricsContext));
-            } catch (RuntimeException ex) {
-                logger.error("Failed to publish metrics due to exception", ex);
-            }
+        return getRouteMetricsContext(context, request).thenAsync(routeMetricsContext -> {
+            return handler.handle(context, request).thenOnResult(response -> {
+                try {
+                    metricsEventPublisher.publish(buildRouteMetricsEvent(stopwatch, context, request, response, routeMetricsContext));
+                } catch (RuntimeException ex) {
+                    logger.error("Failed to publish metrics due to exception", ex);
+                }
+            });
         });
     }
 
@@ -126,16 +129,18 @@ public class RouteMetricsFilter implements Filter {
         return metricEvent;
     }
 
-    private Map<String, Object> getRouteMetricsContext(Context context, Request request) {
+    private Promise<Map<String, Object>, NeverThrowsException> getRouteMetricsContext(Context context, Request request) {
         try {
-            final Map<String, Object> metricsContext = metricsContextSupplier.getMetricsContext(context, request);
-            if (metricsContext != null) {
-                return metricsContext;
-            }
+            return metricsContextSupplier.getMetricsContext(context, request)
+                                         .thenCatchRuntimeException(rte -> {
+                                             logger.error("Unexpected exception thrown invoking metricsContextSupplier", rte);
+                                             return Collections.emptyMap();
+                                         })
+                                         .then(metricsContext -> requireNonNullElse(metricsContext, Collections.emptyMap()));
         } catch (RuntimeException ex) {
             logger.error("Unexpected exception thrown invoking metricsContextSupplier", ex);
+            return Promises.newResultPromise(Collections.emptyMap());
         }
-        return Collections.emptyMap();
     }
 
     /**


### PR DESCRIPTION
MetricsContextSupplier interface now returns a Promise.

TokenEndpointMetricsContextSupplier implements MetricsContextSupplier, and now accesses the Request's Form entity asynchronously; which removes the blocking IO call. 

https://github.com/SecureApiGateway/SecureApiGateway/issues/1115