### PR TITLE
1400: Using RegistrationRequest object in FapiAdvancedDCRValidationFilter validation

### DIFF
--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/common/jwt/ClaimsSetFacade.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/common/jwt/ClaimsSetFacade.java
@@ -60,6 +60,10 @@ public class ClaimsSetFacade {
         return hasExpired;
     }
 
+    public boolean hasClaim(String claimName) {
+        return claimsSet.getClaim(claimName) != null;
+    }
+
     /**
      * Get a String type claim from the JWT
      *

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/models/RegistrationRequest.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/models/RegistrationRequest.java
@@ -44,7 +44,7 @@ public class RegistrationRequest extends SapiJwt {
     private final SoftwareStatement softwareStatement;
     private final List<URI> redirectUris;
 
-    public RegistrationRequest(Builder builder){
+    private RegistrationRequest(Builder builder){
         super(builder);
         this.softwareStatement = builder.softwareStatement;
         this.redirectUris = builder.redirectUris;

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/models/SoftwareStatement.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/models/SoftwareStatement.java
@@ -57,7 +57,7 @@ public class SoftwareStatement extends SapiJwt {
      *
      * @param builder a {@code SoftwareStatement.Builder}
      */
-    public SoftwareStatement(Builder builder) {
+    private SoftwareStatement(Builder builder) {
         super(builder);
         this.orgId = builder.orgId;
         this.orgName = builder.orgName;

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/fapi/v1/FapiAdvancedDCRValidationFilterTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/fapi/v1/FapiAdvancedDCRValidationFilterTest.java
@@ -16,9 +16,13 @@
 package com.forgerock.sapi.gateway.fapi.v1;
 
 import static com.forgerock.sapi.gateway.util.CryptoUtils.convertToPem;
+import static com.forgerock.sapi.gateway.util.CryptoUtils.createEncodedJwtString;
 import static com.forgerock.sapi.gateway.util.CryptoUtils.generateExpiredX509Cert;
 import static com.forgerock.sapi.gateway.util.CryptoUtils.generateRsaKeyPair;
 import static com.forgerock.sapi.gateway.util.CryptoUtils.generateX509Cert;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.forgerock.json.JsonValue.array;
 import static org.forgerock.json.JsonValue.field;
 import static org.forgerock.json.JsonValue.json;
@@ -28,19 +32,20 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.security.NoSuchAlgorithmException;
-import java.text.ParseException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import org.forgerock.http.header.ContentTypeHeader;
 import org.forgerock.http.header.GenericHeader;
@@ -49,11 +54,14 @@ import org.forgerock.http.protocol.Response;
 import org.forgerock.http.protocol.Status;
 import org.forgerock.json.JsonValue;
 import org.forgerock.json.JsonValueException;
+import org.forgerock.json.jose.jwt.JwtClaimsSet;
 import org.forgerock.openig.heap.HeapException;
 import org.forgerock.openig.heap.HeapImpl;
 import org.forgerock.openig.heap.Name;
 import org.forgerock.services.TransactionId;
 import org.forgerock.services.context.AttributesContext;
+import org.forgerock.services.context.Context;
+import org.forgerock.services.context.RootContext;
 import org.forgerock.services.context.TransactionIdContext;
 import org.forgerock.util.promise.NeverThrowsException;
 import org.forgerock.util.promise.Promise;
@@ -63,59 +71,68 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import com.forgerock.sapi.gateway.dcr.common.exceptions.ValidationException;
-import com.forgerock.sapi.gateway.dcr.common.Validator;
+import com.forgerock.sapi.gateway.common.jwt.ClaimsSetFacade;
 import com.forgerock.sapi.gateway.dcr.common.DCRErrorCode;
+import com.forgerock.sapi.gateway.dcr.common.Validator;
+import com.forgerock.sapi.gateway.dcr.common.exceptions.ValidationException;
+import com.forgerock.sapi.gateway.dcr.models.RegistrationRequest;
+import com.forgerock.sapi.gateway.dcr.models.RegistrationRequest.Builder;
+import com.forgerock.sapi.gateway.dcr.models.SoftwareStatement;
+import com.forgerock.sapi.gateway.dcr.models.SoftwareStatementTestFactory;
+import com.forgerock.sapi.gateway.dcr.request.DCRRegistrationRequestBuilderException;
 import com.forgerock.sapi.gateway.fapi.v1.FapiAdvancedDCRValidationFilter.Heaplet;
+import com.forgerock.sapi.gateway.jws.JwtDecoder;
 import com.forgerock.sapi.gateway.mtls.HeaderCertificateRetriever;
+import com.forgerock.sapi.gateway.trusteddirectories.TrustedDirectoryTestFactory;
+import com.forgerock.sapi.gateway.util.CryptoUtils;
 import com.forgerock.sapi.gateway.util.TestHandlers.TestSuccessResponseHandler;
-import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
-import com.nimbusds.jose.JWSHeader;
-import com.nimbusds.jose.crypto.RSASSASigner;
-import com.nimbusds.jwt.JWTClaimsSet;
-import com.nimbusds.jwt.SignedJWT;
 
 class FapiAdvancedDCRValidationFilterTest {
 
     private static final String CERT_HEADER_NAME = "x-cert";
 
     private static final String TEST_CERT_PEM = convertToPem(generateX509Cert(generateRsaKeyPair(), "CN=fapitest"));
-
-    private static RSASSASigner RSA_SIGNER;
-    private static Map<String, Object> VALID_REG_REQUEST_OBJ;
+    private static final JwtDecoder JWT_DECODER = new JwtDecoder();
     private static final HeapImpl EMPTY_HEAP = new HeapImpl(Name.of("testHeap"));
+
+    private static Map<String, Object> VALID_REG_REQUEST_CLAIMS;
+    private static RegistrationRequest VALID_REG_REQUEST;
 
     private TestSuccessResponseHandler successHandler;
 
     private FapiAdvancedDCRValidationFilter fapiValidationFilter;
 
     @BeforeAll
-    public static void beforeAll() throws NoSuchAlgorithmException {
-        RSA_SIGNER = createRSASSASigner();
-        VALID_REG_REQUEST_OBJ = Map.of("token_endpoint_auth_method", "private_key_jwt",
+    public static void beforeAll() throws DCRRegistrationRequestBuilderException {
+        final Map<String, Object> ssaClaims = SoftwareStatementTestFactory.getValidJwksBasedSsaClaims(Map.of());
+        final String ssaJwt = CryptoUtils.createEncodedJwtString(ssaClaims, JWSAlgorithm.PS256);
+        VALID_REG_REQUEST_CLAIMS = Map.of("iss", "ACME Fintech",
+                                       "token_endpoint_auth_method", "private_key_jwt",
                                        "scope", "openid accounts payments",
                                        "redirect_uris", List.of("https://google.co.uk"),
                                        "response_types", List.of("code id_token"),
                                        "token_endpoint_auth_signing_alg", "PS256",
                                        "id_token_signed_response_alg", "PS256",
-                                       "request_object_signing_alg", "PS256");
+                                       "request_object_signing_alg", "PS256",
+                                       "software_statement", ssaJwt);
+
+        VALID_REG_REQUEST = createRegistrationRequest(VALID_REG_REQUEST_CLAIMS);
+    }
+
+    private static RegistrationRequest createRegistrationRequest(Map<String, Object> claims) throws DCRRegistrationRequestBuilderException {
+        final SoftwareStatement.Builder softwareStatementBuilder = new SoftwareStatement.Builder(
+                TrustedDirectoryTestFactory.getTrustedDirectoryService(), JWT_DECODER);
+
+        final Builder registrationRequestBuilder = new Builder(softwareStatementBuilder, JWT_DECODER);
+
+        return registrationRequestBuilder.build(createEncodedJwtString(claims, JWSAlgorithm.PS256));
     }
 
     @BeforeEach
     public void beforeEach() throws HeapException {
         fapiValidationFilter = createDefaultFapiFilter();
         successHandler = new TestSuccessResponseHandler();
-    }
-
-    /**
-     * JWT signer which uses generated test RSA private key
-     */
-    private static RSASSASigner createRSASSASigner() throws NoSuchAlgorithmException {
-        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
-        generator.initialize(2048);
-        KeyPair pair = generator.generateKeyPair();
-        return new RSASSASigner(pair.getPrivate());
     }
 
     /**
@@ -126,20 +143,6 @@ class FapiAdvancedDCRValidationFilterTest {
         return (FapiAdvancedDCRValidationFilter) new FapiAdvancedDCRValidationFilter.Heaplet()
                                                                                     .create(Name.of("fapiTest"),
                                                                                             filterConfig, EMPTY_HEAP);
-    }
-
-    private String createSignedJwt(Map<String, Object> claims) {
-        return createSignedJwt(claims, JWSAlgorithm.PS256);
-    }
-
-    private String createSignedJwt(Map<String, Object> claims, JWSAlgorithm signingAlgo) {
-        try {
-            final SignedJWT signedJWT = new SignedJWT(new JWSHeader(signingAlgo), JWTClaimsSet.parse(claims));
-            signedJWT.sign(RSA_SIGNER);
-            return signedJWT.serialize();
-        } catch (ParseException | JOSEException e) {
-            throw new RuntimeException(e);
-        }
     }
 
     private void validateErrorResponse(Response response, DCRErrorCode expectedErrorCode, String expectedErrorDescription) {
@@ -154,14 +157,11 @@ class FapiAdvancedDCRValidationFilterTest {
         }
     }
 
-    private void submitRequestAndValidateSuccessful(String httpMethod, Map<String, Object> validRegRequestObj,
-            String testCertPem, FapiAdvancedDCRValidationFilter filter) throws Exception {
-        final TransactionIdContext context = new TransactionIdContext(null, new TransactionId("1234"));
+    private void submitRequestAndValidateSuccessful(String httpMethod, FapiAdvancedDCRValidationFilter filter) throws Exception {
         final Request request = new Request().setMethod(httpMethod);
-        request.addHeaders(new GenericHeader(CERT_HEADER_NAME, URLEncoder.encode(testCertPem, StandardCharsets.UTF_8)));
+        request.addHeaders(new GenericHeader(CERT_HEADER_NAME, URLEncoder.encode(TEST_CERT_PEM, StandardCharsets.UTF_8)));
 
-        final String signedJwt = createSignedJwt(validRegRequestObj);
-        request.getEntity().setString(signedJwt);
+        final Context context = createContext(VALID_REG_REQUEST);
 
         final Promise<Response, NeverThrowsException> responsePromise = filter.filter(context, request, successHandler);
         final Response response = responsePromise.get(1, TimeUnit.SECONDS);
@@ -171,69 +171,74 @@ class FapiAdvancedDCRValidationFilterTest {
         assertTrue(successHandler.hasBeenInteractedWith(), "Filter was expected to pass the request on to the successHandler");
     }
 
+    private static Context createContext(RegistrationRequest registrationRequest) {
+        final AttributesContext attributesContext = new AttributesContext(new RootContext());
+        attributesContext.getAttributes().put(RegistrationRequest.REGISTRATION_REQUEST_KEY, registrationRequest);
+        return new TransactionIdContext(attributesContext, new TransactionId("1234"));
+    }
+
     /**
      * Tests for the individual validators which validate particular fields within the Registration Request JWT.
      */
     @Nested
     class RegistrationRequestObjectFieldValidatorTests {
 
-        private <T> void runValidationAndVerifyExceptionThrown(Validator<T> validator, T requestObject,
-                DCRErrorCode expectedErrorCode, String expectedErrorMessage) {
+        private <T> void runValidationAndVerifyExceptionThrown(Validator<RegistrationRequest> validator,
+                RegistrationRequest registrationRequest, DCRErrorCode expectedErrorCode, String expectedErrorMessage) {
             final ValidationException validationException = Assertions.assertThrows(ValidationException.class,
-                    () -> validator.validate(requestObject));
+                    () -> validator.validate(registrationRequest));
             assertEquals(expectedErrorCode, validationException.getErrorCode(), "errorCode field");
             assertEquals(expectedErrorMessage, validationException.getErrorDescription(), "errorMessage field");
         }
 
-
         @Test
-        void redirectUrisFieldMissing() {
-            final JsonValue missingField = json(object());
-            runValidationAndVerifyExceptionThrown(fapiValidationFilter::validateRedirectUris, missingField,
-                    DCRErrorCode.INVALID_REDIRECT_URI, "request object must contain redirect_uris field");
-        }
-
-        @Test
-        void redirectUrisArrayEmpty() {
-            final JsonValue emptyArray = json(object(field("redirect_uris", array())));
-            runValidationAndVerifyExceptionThrown(fapiValidationFilter::validateRedirectUris, emptyArray,
+        void failsWhenRedirectUrisArrayEmpty() {
+            final RegistrationRequest registrationRequest = mock(RegistrationRequest.class);
+            when(registrationRequest.getRedirectUris()).thenReturn(List.of());
+            runValidationAndVerifyExceptionThrown(fapiValidationFilter::validateRedirectUris, registrationRequest,
                     DCRErrorCode.INVALID_REDIRECT_URI, "redirect_uris array must not be empty");
         }
 
         @Test
-        void redirectUrisNonHttpsUri() {
-            final JsonValue nonHttpsRedirect = json(object(field("redirect_uris",
-                    array("https://www.google.com", "http://www.google.co.uk"))));
-            runValidationAndVerifyExceptionThrown(fapiValidationFilter::validateRedirectUris, nonHttpsRedirect,
+        void failsWhenRedirectUrisNonHttpsUri() {
+            final RegistrationRequest registrationRequest = mock(RegistrationRequest.class);
+            final List<URI> uris = Stream.of("https://www.google.com", "http://www.google.co.uk").map(URI::create).toList();
+            when(registrationRequest.getRedirectUris()).thenReturn(uris);
+            runValidationAndVerifyExceptionThrown(fapiValidationFilter::validateRedirectUris, registrationRequest,
                     DCRErrorCode.INVALID_REDIRECT_URI, "redirect_uris must use https scheme");
         }
 
         @Test
-        void redirectUrisMalformedUri() {
-            final JsonValue nonHttpsRedirect = json(object(field("redirect_uris", array("https://www.google.com", "123:@///324dfs+w34r"))));
-            runValidationAndVerifyExceptionThrown(fapiValidationFilter::validateRedirectUris, nonHttpsRedirect,
-                    DCRErrorCode.INVALID_REDIRECT_URI, "redirect_uri: 123:@///324dfs+w34r is not a valid URI");
+        void failsWhenRedirectUrisContainsLocalhost() {
+            final RegistrationRequest registrationRequest = mock(RegistrationRequest.class);
+            final List<URI> uris = Stream.of("https://www.google.com", "https://localhost:8080/blah").map(URI::create).toList();
+            when(registrationRequest.getRedirectUris()).thenReturn(uris);
+            runValidationAndVerifyExceptionThrown(fapiValidationFilter::validateRedirectUris, registrationRequest,
+                    DCRErrorCode.INVALID_REDIRECT_URI, "redirect_uris must not contain localhost");
         }
 
         @Test
         void validRedirectUris() {
-            final JsonValue validRedirect = json(object(field("redirect_uris", array("https://www.google.com", "https://www.google.co.uk"))));
-            fapiValidationFilter.validateRedirectUris(validRedirect);
+            final RegistrationRequest registrationRequest = mock(RegistrationRequest.class);
+            final List<URI> uris = Stream.of("https://www.google.com", "https://www.google.co.uk").map(URI::create).toList();
+            when(registrationRequest.getRedirectUris()).thenReturn(uris);
+            fapiValidationFilter.validateRedirectUris(registrationRequest);
         }
 
         @Test
-        void tokenEndpointAuthMethodFieldMissing() {
-            final JsonValue missingField = json(object());
-            runValidationAndVerifyExceptionThrown(fapiValidationFilter::validateTokenEndpointAuthMethods, missingField,
+        void failsWhenTokenEndpointAuthMethodFieldMissing() {
+            final RegistrationRequest registrationRequest = mock(RegistrationRequest.class);
+            when(registrationRequest.getClaimsSet()).thenReturn(new ClaimsSetFacade(new JwtClaimsSet(Map.of())));
+            runValidationAndVerifyExceptionThrown(fapiValidationFilter::validateTokenEndpointAuthMethods, registrationRequest,
                     DCRErrorCode.INVALID_CLIENT_METADATA, "request object must contain field: token_endpoint_auth_method");
         }
 
         @Test
-        void tokenEndpointAuthMethodValueNotSupported() {
-            final String[] invalidAuthMethods = new String[]{"", "none", "client_secret"};
+        void failsWhenTokenEndpointAuthMethodValueNotSupported() {
+            final String[] invalidAuthMethods = new String[]{"none", "client_secret"};
             for (String invalidAuthMethod : invalidAuthMethods) {
-                final JsonValue invalidAuthMethodJson = json(object(field("token_endpoint_auth_method", invalidAuthMethod)));
-                runValidationAndVerifyExceptionThrown(fapiValidationFilter::validateTokenEndpointAuthMethods, invalidAuthMethodJson,
+                final RegistrationRequest registrationRequest = mockRegistrationRequest(Map.of("token_endpoint_auth_method", invalidAuthMethod));
+                runValidationAndVerifyExceptionThrown(fapiValidationFilter::validateTokenEndpointAuthMethods, registrationRequest,
                         DCRErrorCode.INVALID_CLIENT_METADATA, "token_endpoint_auth_method not supported, must be one of: [private_key_jwt, self_signed_tls_client_auth, tls_client_auth]");
             }
         }
@@ -242,8 +247,10 @@ class FapiAdvancedDCRValidationFilterTest {
         void tokenEndpointAuthMethodValid() {
             final String[] validMethods = new String[]{"private_key_jwt", "self_signed_tls_client_auth", "tls_client_auth"};
             for (String validAuthMethod : validMethods) {
-                final JsonValue validAuthMethodJson = json(object(field("token_endpoint_auth_method", validAuthMethod)));
-                fapiValidationFilter.validateTokenEndpointAuthMethods(validAuthMethodJson);
+                final Map<String, Object> claims = Map.of("token_endpoint_auth_method", validAuthMethod);
+                final RegistrationRequest registrationRequest = mockRegistrationRequest(claims);
+
+                fapiValidationFilter.validateTokenEndpointAuthMethods(registrationRequest);
             }
         }
 
@@ -254,37 +261,42 @@ class FapiAdvancedDCRValidationFilterTest {
 
             // Test submitting requests which each omit one of the fields in turn
             for (String fieldToOmit : signingAlgoFields) {
-                final JsonValue registrationRequest = json(object());
-                signingAlgoFields.stream().filter(field -> !field.equals(fieldToOmit)).forEach(field -> registrationRequest.add(field, "PS256"));
+                final Map<String, Object> signingFields = new HashMap<>();
+                 signingAlgoFields.stream()
+                                  .filter(field -> !field.equals(fieldToOmit))
+                                  .forEach(field -> signingFields.put(field, "PS256"));
+                final RegistrationRequest registrationRequest = mockRegistrationRequest(signingFields);
                 fapiValidationFilter.validateSigningAlgorithmUsed(registrationRequest);
             }
         }
 
         @Test
-        void signingAlgorithmFieldsUnsupportedAlgo() {
+        void failsWhenSigningAlgorithmFieldsUnsupportedAlgo() {
             final List<String> signingAlgoFields = List.of("token_endpoint_auth_signing_alg", "id_token_signed_response_alg",
                     "request_object_signing_alg");
 
             // Test submitting requests which each set one of the fields to an invalid algorithm in turn
             for (String invalidAlgoField : signingAlgoFields) {
-                final JsonValue registrationRequest = json(object());
-                signingAlgoFields.stream().filter(field -> !field.equals(invalidAlgoField)).forEach(field -> registrationRequest.add(field, "PS256"));
-                registrationRequest.add(invalidAlgoField, "RS256");
-                runValidationAndVerifyExceptionThrown(fapiValidationFilter::validateSigningAlgorithmUsed, registrationRequest,
+                Map<String, Object> signingFields = new HashMap<>();
+                signingAlgoFields.stream().filter(field -> !field.equals(invalidAlgoField)).forEach(field -> signingFields.put(field, "PS256"));
+                signingFields.put(invalidAlgoField, "RS256");
+                runValidationAndVerifyExceptionThrown(fapiValidationFilter::validateSigningAlgorithmUsed, mockRegistrationRequest(signingFields),
                         DCRErrorCode.INVALID_CLIENT_METADATA, "request object field: " + invalidAlgoField + ", must be one of: [ES256, PS256]");
             }
         }
 
         @Test
         void signingAlgorithmFieldsValid() {
-            fapiValidationFilter.validateSigningAlgorithmUsed(json(object(field("token_endpoint_auth_signing_alg", "PS256"),
-                    field("id_token_signed_response_alg", "PS256"),
-                    field("request_object_signing_alg", "PS256"))));
+            final Map<String, Object> claims = Stream.of("token_endpoint_auth_signing_alg",
+                                                                 "id_token_signed_response_alg",
+                                                                 "request_object_signing_alg")
+                                                     .collect(toMap(identity(), ignore -> "PS256"));
+            fapiValidationFilter.validateSigningAlgorithmUsed(mockRegistrationRequest(claims));
         }
 
         @Test
-        void responseTypeFieldMissing() {
-            runValidationAndVerifyExceptionThrown(fapiValidationFilter::validateResponseTypes, json(object(field("blah", "blah"))),
+        void failsWhenResponseTypeFieldMissing() {
+            runValidationAndVerifyExceptionThrown(fapiValidationFilter::validateResponseTypes, mock(RegistrationRequest.class),
                     DCRErrorCode.INVALID_CLIENT_METADATA, "request object must contain field: response_types");
         }
 
@@ -297,15 +309,29 @@ class FapiAdvancedDCRValidationFilterTest {
                                                                  List.of("id_token code", "code"));
 
             for (List<String> validResponseTypeValue : validResponseTypeValues) {
-                fapiValidationFilter.validateResponseTypes(json(object(field("response_types", array(validResponseTypeValue.toArray())))));
+                final RegistrationRequest registrationRequest = mock(RegistrationRequest.class);
+                when(registrationRequest.getResponseTypes()).thenReturn(Optional.of(validResponseTypeValue));
+
+                fapiValidationFilter.validateResponseTypes(registrationRequest);
             }
         }
 
         @Test
-        void responseTypesInvalid() {
-            runValidationAndVerifyExceptionThrown(fapiValidationFilter::validateResponseTypes, json(object(field("response_types", array("blah")))),
+        void failsWhenResponseTypesInvalid() {
+            final RegistrationRequest registrationRequest = mock(RegistrationRequest.class);
+            when(registrationRequest.getResponseTypes()).thenReturn(Optional.of(List.of("blah")));
+
+            runValidationAndVerifyExceptionThrown(fapiValidationFilter::validateResponseTypes, registrationRequest,
                     DCRErrorCode.INVALID_CLIENT_METADATA, "Invalid response_types value: blah, must be one of: \"code\" or \"code id_token\"");
         }
+    }
+
+    private static RegistrationRequest mockRegistrationRequest(Map<String, Object> claims) {
+        final RegistrationRequest registrationRequest = mock(RegistrationRequest.class);
+        final ClaimsSetFacade claimsSetFacade = new ClaimsSetFacade(new JwtClaimsSet(claims));
+        when(registrationRequest.getClaimsSet()).thenReturn(claimsSetFacade);
+        when(registrationRequest.getResponseTypes()).thenCallRealMethod();
+        return registrationRequest;
     }
 
     /**
@@ -317,8 +343,8 @@ class FapiAdvancedDCRValidationFilterTest {
 
         @Test
         void validRequest() throws Exception{
-            submitRequestAndValidateSuccessful("POST", VALID_REG_REQUEST_OBJ, TEST_CERT_PEM, fapiValidationFilter);
-            submitRequestAndValidateSuccessful("PUT", VALID_REG_REQUEST_OBJ, TEST_CERT_PEM, fapiValidationFilter);
+            submitRequestAndValidateSuccessful("POST", fapiValidationFilter);
+            submitRequestAndValidateSuccessful("PUT", fapiValidationFilter);
         }
 
         @Test
@@ -344,15 +370,26 @@ class FapiAdvancedDCRValidationFilterTest {
         }
 
         @Test
-        void invalidRequestFailsFieldLevelValidation() throws Exception {
-            final TransactionIdContext context = new TransactionIdContext(null, new TransactionId("1234"));
+        void failsWithRuntimeExceptionIfRegistrationRequestObjectNotFound() {
             final Request request = new Request().setMethod("POST");
             request.addHeaders(new GenericHeader(CERT_HEADER_NAME, URLEncoder.encode(TEST_CERT_PEM, StandardCharsets.UTF_8)));
 
-            final Map<String, Object> invalidRegistrationRequest = new HashMap<>(VALID_REG_REQUEST_OBJ);
+            // No registrationRequest in context
+            final Context context = new AttributesContext(new RootContext());
+
+            final IllegalStateException illegalStateException = assertThrows(IllegalStateException.class,
+                    () -> fapiValidationFilter.filter(context, request, successHandler));
+            assertThat(illegalStateException).hasMessageContaining("Required attribute: \"registrationRequest\" not found in context");
+        }
+
+        @Test
+        void invalidRequestFailsFieldLevelValidation() throws Exception {
+            final Request request = new Request().setMethod("POST");
+            request.addHeaders(new GenericHeader(CERT_HEADER_NAME, URLEncoder.encode(TEST_CERT_PEM, StandardCharsets.UTF_8)));
+
+            final Map<String, Object> invalidRegistrationRequest = new HashMap<>(VALID_REG_REQUEST_CLAIMS);
             invalidRegistrationRequest.put("token_endpoint_auth_method", "blah"); // invalidate one of the fields
-            final String signedJwt = createSignedJwt(invalidRegistrationRequest);
-            request.getEntity().setString(signedJwt);
+            final Context context = createContext(createRegistrationRequest(invalidRegistrationRequest));
 
             final Promise<Response, NeverThrowsException> responsePromise = fapiValidationFilter.filter(context, request, successHandler);
 
@@ -365,12 +402,9 @@ class FapiAdvancedDCRValidationFilterTest {
 
         @Test
         void invalidRequestMissingCert() throws Exception {
-            final TransactionIdContext context = new TransactionIdContext(null, new TransactionId("1234"));
             final Request request = new Request().setMethod("POST");
 
-            final Map<String, Object> validRegRequestObj = VALID_REG_REQUEST_OBJ;
-            final String signedJwt = createSignedJwt(validRegRequestObj);
-            request.getEntity().setString(signedJwt);
+            final Context context = createContext(VALID_REG_REQUEST);
 
             final Promise<Response, NeverThrowsException> responsePromise = fapiValidationFilter.filter(context, request, successHandler);
 
@@ -381,15 +415,11 @@ class FapiAdvancedDCRValidationFilterTest {
 
         @Test
         void invalidRequestMalformedCert() throws Exception {
-            final TransactionIdContext context = new TransactionIdContext(null, new TransactionId("1234"));
             final Request request = new Request().setMethod("POST");
             // %-1 is an invalid URL escape code
             request.addHeaders(new GenericHeader(CERT_HEADER_NAME, "%-1this is not URL encoded properly"));
 
-            final Map<String, Object> validRegRequestObj = VALID_REG_REQUEST_OBJ;
-            final String signedJwt = createSignedJwt(validRegRequestObj);
-            request.getEntity().setString(signedJwt);
-
+            final Context context = createContext(VALID_REG_REQUEST);
             final Promise<Response, NeverThrowsException> responsePromise = fapiValidationFilter.filter(context, request, successHandler);
 
             final Response response = responsePromise.get(1, TimeUnit.SECONDS);
@@ -399,14 +429,10 @@ class FapiAdvancedDCRValidationFilterTest {
 
         @Test
         void invalidRequestInvalidCert() throws Exception {
-            final TransactionIdContext context = new TransactionIdContext(null, new TransactionId("1234"));
             final Request request = new Request().setMethod("POST");
             request.addHeaders(new GenericHeader(CERT_HEADER_NAME, URLEncoder.encode("this is an invalid cert......", StandardCharsets.UTF_8)));
 
-            final Map<String, Object> validRegRequestObj = VALID_REG_REQUEST_OBJ;
-            final String signedJwt = createSignedJwt(validRegRequestObj);
-            request.getEntity().setString(signedJwt);
-
+            final Context context = createContext(VALID_REG_REQUEST);
             final Promise<Response, NeverThrowsException> responsePromise = fapiValidationFilter.filter(context, request, successHandler);
 
             final Response response = responsePromise.get(1, TimeUnit.SECONDS);
@@ -416,15 +442,11 @@ class FapiAdvancedDCRValidationFilterTest {
 
         @Test
         void invalidRequestExpiredCert() throws Exception {
-            final TransactionIdContext context = new TransactionIdContext(null, new TransactionId("1234"));
             final Request request = new Request().setMethod("POST");
             request.addHeaders(new GenericHeader(CERT_HEADER_NAME, URLEncoder.encode(
                     convertToPem(generateExpiredX509Cert(generateRsaKeyPair(), "CN=test")), Charset.defaultCharset())));
 
-            final Map<String, Object> validRegRequestObj = VALID_REG_REQUEST_OBJ;
-            final String signedJwt = createSignedJwt(validRegRequestObj);
-            request.getEntity().setString(signedJwt);
-
+            final Context context = createContext(VALID_REG_REQUEST);
             final Promise<Response, NeverThrowsException> responsePromise = fapiValidationFilter.filter(context, request, successHandler);
 
             final Response response = responsePromise.get(1, TimeUnit.SECONDS);
@@ -434,47 +456,16 @@ class FapiAdvancedDCRValidationFilterTest {
         }
 
         @Test
-        void invalidRequestInvalidJwt() throws Exception {
-            final TransactionIdContext context = new TransactionIdContext(null, new TransactionId("1234"));
-            final Request request = new Request().setMethod("POST");
-            request.addHeaders(new GenericHeader(CERT_HEADER_NAME, URLEncoder.encode(TEST_CERT_PEM, StandardCharsets.UTF_8)));
-            request.getEntity().setString("plain text instead of a JWT");
-
-            final Promise<Response, NeverThrowsException> responsePromise = fapiValidationFilter.filter(context, request, successHandler);
-
-            final Response response = responsePromise.get(1, TimeUnit.SECONDS);
-            Assertions.assertFalse(response.getStatus().isSuccessful(), "Request must fail");
-            validateErrorResponse(response, DCRErrorCode.INVALID_CLIENT_METADATA, "registration request entity is missing or malformed");
-        }
-
-        @Test
-        void invalidRequestJwtSignedWithUnsupportedAlgo() throws Exception {
-            final TransactionIdContext context = new TransactionIdContext(null, new TransactionId("1234"));
-            final Request request = new Request().setMethod("POST");
-            request.addHeaders(new GenericHeader(CERT_HEADER_NAME, URLEncoder.encode(TEST_CERT_PEM, StandardCharsets.UTF_8)));
-
-            // RS256 JWT signing algorithm not supported
-            final String signedJwt = createSignedJwt(VALID_REG_REQUEST_OBJ, JWSAlgorithm.RS256);
-            request.getEntity().setString(signedJwt);
-
-            final Promise<Response, NeverThrowsException> responsePromise = fapiValidationFilter.filter(context, request, successHandler);
-
-            final Response response = responsePromise.get(1, TimeUnit.SECONDS);
-            Assertions.assertFalse(response.getStatus().isSuccessful(), "Request must fail");
-            validateErrorResponse(response, DCRErrorCode.INVALID_CLIENT_METADATA, "DCR request JWT signed must be signed with one of: [ES256, PS256]");
-        }
-
-        @Test
         void verifyUnexpectedRuntimeExceptionIsThrownOnByFilter() {
             // Trigger a runtime exception in one of the validators, verify that the exception is thrown on
             final IllegalStateException expectedException = new IllegalStateException("this should not have happened");
-            final Validator<JsonValue> brokenValidator = req -> {
+            final Validator<RegistrationRequest> brokenValidator = req -> {
                 throw expectedException;
             };
             fapiValidationFilter.setRegistrationRequestObjectValidators(List.of(brokenValidator));
 
             final IllegalStateException actualException = assertThrows(IllegalStateException.class,
-                    () -> submitRequestAndValidateSuccessful("POST", VALID_REG_REQUEST_OBJ, TEST_CERT_PEM, fapiValidationFilter));
+                    () -> submitRequestAndValidateSuccessful("POST", fapiValidationFilter));
             assertSame(expectedException, actualException);
         }
     }
@@ -524,9 +515,9 @@ class FapiAdvancedDCRValidationFilterTest {
 
             final FapiAdvancedDCRValidationFilter filter = (FapiAdvancedDCRValidationFilter) new Heaplet().create(Name.of("fapiTest"), filterConfig, EMPTY_HEAP);
 
-            final Map<String, Object> validRegRequestObj = new HashMap<>(VALID_REG_REQUEST_OBJ);
+            final Map<String, Object> validRegRequestObj = new HashMap<>(VALID_REG_REQUEST_CLAIMS);
             validRegRequestObj.put("additional_signing_field_to_validate", "PS256"); // Add a value for the extra signing field that was configured via conf
-            submitRequestAndValidateSuccessful("POST", validRegRequestObj, TEST_CERT_PEM, filter);
+            submitRequestAndValidateSuccessful("POST", filter);
         }
 
         @Test
@@ -547,9 +538,9 @@ class FapiAdvancedDCRValidationFilterTest {
 
             final FapiAdvancedDCRValidationFilter filter = (FapiAdvancedDCRValidationFilter) new Heaplet().create(Name.of("fapiTest"), filterConfig, heap);
 
-            final Map<String, Object> validRegRequestObj = new HashMap<>(VALID_REG_REQUEST_OBJ);
+            final Map<String, Object> validRegRequestObj = new HashMap<>(VALID_REG_REQUEST_CLAIMS);
             validRegRequestObj.put("additional_signing_field_to_validate", "PS256"); // Add a value for the extra signing field that was configured via conf
-            submitRequestAndValidateSuccessful("POST", validRegRequestObj, TEST_CERT_PEM, filter);
+            submitRequestAndValidateSuccessful("POST", filter);
         }
     }
 }


### PR DESCRIPTION
The RegistrationRequest sourced from the AttributesContext is validated by the filter. This removes duplicate logic for extracting the data from the HTTP request entity directly.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1400