### PR TITLE
1417: Add workaround for AM PAR endpoint bug requiring client_id param

### DIFF
--- a/config/7.3.0/fapi1part2adv/ig/routes/routes-service/22-as-par-endpoint.json
+++ b/config/7.3.0/fapi1part2adv/ig/routes/routes-service/22-as-par-endpoint.json
@@ -37,6 +37,15 @@
           "comment": "Ensure authorize request object is FAPI compliant"
         },
         {
+          "name": "FixParParamsForAm",
+          "comment": "Workaround for an AM bug in the /par endpoint",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "FixParParamsForAm.groovy"
+          }
+        },
+        {
           "name": "ResponsePathTransportCertValidationFilter",
           "type": "ResponsePathTransportCertValidationFilter",
           "comment": "Verify that the client's transport cert is valid and is mapped to their SSA",

--- a/config/7.3.0/fapi1part2adv/ig/scripts/groovy/FixParParamsForAm.groovy
+++ b/config/7.3.0/fapi1part2adv/ig/scripts/groovy/FixParParamsForAm.groovy
@@ -1,0 +1,35 @@
+/**
+ * Workaround for AM issue: https://bugster.forgerock.org/jira/browse/OPENAM-21910
+ * AM is expecting that the client_id is always supplied as a parameter when calling the /par endpoint.
+ *
+ * This should only be the case when the client_id is needed to authenticate the client i.e. when doing tls_client_auth,
+ * for other auth methods, such as private_key_jwt, the client_id should not be supplied.
+ *
+ * This filter adds the client_id param if it is missing, sourcing the value from the request JWT param's iss claim.
+ */
+
+import org.forgerock.json.jose.common.JwtReconstruction
+import org.forgerock.json.jose.jws.SignedJwt
+
+SCRIPT_NAME = "[FixParParamsForAm] "
+logger.debug(SCRIPT_NAME + "Running...")
+
+def form = request.getEntity().getForm()
+if (!form.containsKey("client_id")) {
+    addClientIdParamToRequest(form)
+}
+next.handle(context, request)
+
+private void addClientIdParamToRequest(form) {
+    def requestJwtString = form.getFirst("request")
+    try {
+        def requestJwt = new JwtReconstruction().reconstructJwt(requestJwtString, SignedJwt.class)
+        def clientId = requestJwt.getClaimsSet().getIssuer()
+        form.add("client_id", clientId)
+        logger.debug("{}Adding client_id: {} to request params", SCRIPT_NAME, clientId)
+        request.setEntity(form)
+    } catch (e) {
+        logger.warn(SCRIPT_NAME + "failed to add client_id to request", e)
+    }
+}
+


### PR DESCRIPTION
An AM bug exists which requires the client_id param be supplied in all calls to the /par endpoint, see https://bugster.forgerock.org/jira/browse/OPENAM-21910

According to the spec, the client_id is only required when it is needed as an authentication param i.e. when the client is doing tls_client_auth. If the client is doing private_key_jwt auth then the client_id is not a required param.

This workaround uses a filter to add the client_id param if it is missing, the value is sourced from the request JWT param's iss claim.

The workaround is best-effort, if an error occurs it is ignored and the call is allowed to pass through to AM.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1417