### PR TITLE
846: Create DNS for new stand alone test trusted directory and update relevant configs

### DIFF
--- a/config/7.3.0/fapi1part2adv/ig/config/dev/config/config.json
+++ b/config/7.3.0/fapi1part2adv/ig/config/dev/config/config.json
@@ -346,7 +346,7 @@
             "name": "Secure API Gateway Test Directory",
             "type": "TrustedDirectory",
             "config": {
-              "directoryJwksUri": "https://&{ig.fqdn}/jwkms/testdirectory/jwks",
+              "directoryJwksUri": "https://&{trusteddir.fqdn}/jwkms/testdirectory/jwks",
               "issuer": "test-publisher",
               "softwareStatementJwksClaimName": "software_jwks",
               "softwareStatementOrgIdClaimName": "org_id",

--- a/config/7.3.0/fapi1part2adv/ig/config/prod/config/config.json
+++ b/config/7.3.0/fapi1part2adv/ig/config/prod/config/config.json
@@ -334,7 +334,7 @@
             "name": "Secure API Gateway Test Directory",
             "type": "TrustedDirectory",
             "config": {
-              "directoryJwksUri": "https://&{ig.fqdn}/jwkms/testdirectory/jwks",
+              "directoryJwksUri": "https://&{trusteddir.fqdn}/jwkms/testdirectory/jwks",
               "issuer": "test-publisher",
               "softwareStatementJwksClaimName": "software_jwks",
               "softwareStatementOrgIdClaimName": "org_id",


### PR DESCRIPTION
Update variable placeholder for any config that uses the jwkms endpoint to use new test trusted directory FQDN

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/846