### PR TITLE
1428: Configure Test Trusted Directory to use SSA jwks_uri claim

### DIFF
--- a/config/7.3.0/fapi1part2adv/ig/config/dev/config/config.json
+++ b/config/7.3.0/fapi1part2adv/ig/config/dev/config/config.json
@@ -348,7 +348,7 @@
             "config": {
               "directoryJwksUri": "https://&{trusteddir.fqdn}/jwkms/testdirectory/jwks",
               "issuer": "test-publisher",
-              "softwareStatementJwksClaimName": "software_jwks",
+              "softwareStatementJwksUriClaimName": "software_jwks_endpoint",
               "softwareStatementOrgIdClaimName": "org_id",
               "softwareStatementOrgNameClaimName": "org_name",
               "softwareStatementSoftwareIdClaimName": "software_id",

--- a/config/7.3.0/fapi1part2adv/ig/config/prod/config/config.json
+++ b/config/7.3.0/fapi1part2adv/ig/config/prod/config/config.json
@@ -336,7 +336,7 @@
             "config": {
               "directoryJwksUri": "https://&{trusteddir.fqdn}/jwkms/testdirectory/jwks",
               "issuer": "test-publisher",
-              "softwareStatementJwksClaimName": "software_jwks",
+              "softwareStatementJwksUriClaimName": "software_jwks_endpoint",
               "softwareStatementOrgIdClaimName": "org_id",
               "softwareStatementOrgNameClaimName": "org_name",
               "softwareStatementSoftwareIdClaimName": "software_id",


### PR DESCRIPTION
This switches from supporting SSAs with an embedded JWKS to using a jwks_uri to fetch the JWKS for the client from the directory.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1428