### PR TITLE
1475: Upgrade openIG to 2024.6 ready for SAPIG 3.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     </parent>
 
     <properties>
-        <openig.version>2024.3.0</openig.version>
+        <openig.version>2024.6.0</openig.version>
         <nimbus-jose.version>9.39.1</nimbus-jose.version>
         <bouncy-castle.version>1.77</bouncy-castle.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>

--- a/secure-api-gateway-core-docker/Dockerfile
+++ b/secure-api-gateway-core-docker/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM gcr.io/forgerock-io/ig:2024.3.0
+FROM gcr.io/forgerock-io/ig:2024.6.0
 # Switching back to forgerock user, app will run as this
 USER forgerock
 # Create dir where secrets can be mounted into


### PR DESCRIPTION
Bump docker image and Pom version to latest release version 2024.6.0

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1475

Testing: PR Image running on dev-core
![image](https://github.com/SecureApiGateway/secure-api-gateway-core/assets/115990205/d1abce29-f1e8-4c21-a9f7-10cbe3d2dedd)

Test Result: https://g.codefresh.io/build/6686ac05c60584a75fc47734
