### PR TITLE
1507: Support making ig-truststore-pem secret optional for core deployment

### DIFF
--- a/secure-api-gateway-core-docker/7.3.0/ig/bin/import-pem-certs.sh
+++ b/secure-api-gateway-core-docker/7.3.0/ig/bin/import-pem-certs.sh
@@ -23,26 +23,30 @@ set -o pipefail
 
 IG_DEFAULT_TRUSTSTORE=${IG_DEFAULT_TRUSTSTORE:-$JAVA_HOME/lib/security/cacerts}
 # If a $IG_PEM_TRUSTSTORE is provided, import it into the truststore. Otherwise, do nothing
-if [ -f "$IG_DEFAULT_TRUSTSTORE" ] && [ -f "$IG_PEM_TRUSTSTORE" ]; then
+if [ -f "$IG_DEFAULT_TRUSTSTORE" ]; then
     TRUSTSTORE_PATH="${TRUSTSTORE_PATH:-/home/forgerock/igtruststore}"
     TRUSTSTORE_PASSWORD="${TRUSTSTORE_PASSWORD:-changeit}"
     echo "Copying ${IG_DEFAULT_TRUSTSTORE} to ${TRUSTSTORE_PATH}"
     cp ${IG_DEFAULT_TRUSTSTORE} ${TRUSTSTORE_PATH}
     # Calculate the number of certs in the PEM file
-    CERTS=$(grep 'END CERTIFICATE' $IG_PEM_TRUSTSTORE| wc -l)
-    echo "Found (${CERTS}) certificates in $IG_PEM_TRUSTSTORE"
-    echo "Importing (${CERTS}) certificates into ${TRUSTSTORE_PATH}"
-    # For every cert in the PEM file, extract it and import into the JKS truststore
-    for N in $(seq 0 $(($CERTS - 1))); do
-        ALIAS="imported-certs-$N"
-        cat $IG_PEM_TRUSTSTORE |
-            awk "n==$N { print }; /END CERTIFICATE/ { n++ }" |
-            keytool -noprompt -importcert -trustcacerts -storetype PKCS12 \
-                    -alias "${ALIAS}" -keystore "${TRUSTSTORE_PATH}" \
-                    -storepass "${TRUSTSTORE_PASSWORD}"
-    done
-    echo "Import complete!"
+    if [ -f "$IG_PEM_TRUSTSTORE" ]; then
+      CERTS=$(grep 'END CERTIFICATE' $IG_PEM_TRUSTSTORE| wc -l)
+      echo "Found (${CERTS}) certificates in $IG_PEM_TRUSTSTORE"
+      echo "Importing (${CERTS}) certificates into ${TRUSTSTORE_PATH}"
+      # For every cert in the PEM file, extract it and import into the JKS truststore
+      for N in $(seq 0 $(($CERTS - 1))); do
+          ALIAS="imported-certs-$N"
+          cat $IG_PEM_TRUSTSTORE |
+              awk "n==$N { print }; /END CERTIFICATE/ { n++ }" |
+              keytool -noprompt -importcert -trustcacerts -storetype PKCS12 \
+                      -alias "${ALIAS}" -keystore "${TRUSTSTORE_PATH}" \
+                      -storepass "${TRUSTSTORE_PASSWORD}"
+      done
+      echo "Import complete!"
+    else
+      echo "IG_PEM_TRUSTSTORE has no value or doesn't exist, no further import performed"
+    fi
 else
-    echo "Nothing was imported to the truststore. Check ENVs IG_DEFAULT_TRUSTSTORE and IG_PEM_TRUSTSTORE"
+    echo "Nothing was imported to the truststore. Check ENVs IG_DEFAULT_TRUSTSTORE"
     exit 1
 fi

--- a/secure-api-gateway-core-docker/7.3.0/ig/bin/import-pem-certs.sh
+++ b/secure-api-gateway-core-docker/7.3.0/ig/bin/import-pem-certs.sh
@@ -22,7 +22,6 @@ set -e
 set -o pipefail
 
 IG_DEFAULT_TRUSTSTORE=${IG_DEFAULT_TRUSTSTORE:-$JAVA_HOME/lib/security/cacerts}
-# If a $IG_PEM_TRUSTSTORE is provided, import it into the truststore. Otherwise, do nothing
 if [ -f "$IG_DEFAULT_TRUSTSTORE" ]; then
     TRUSTSTORE_PATH="${TRUSTSTORE_PATH:-/home/forgerock/igtruststore}"
     TRUSTSTORE_PASSWORD="${TRUSTSTORE_PASSWORD:-changeit}"
@@ -30,6 +29,7 @@ if [ -f "$IG_DEFAULT_TRUSTSTORE" ]; then
     cp ${IG_DEFAULT_TRUSTSTORE} ${TRUSTSTORE_PATH}
     # Calculate the number of certs in the PEM file
     if [ -f "$IG_PEM_TRUSTSTORE" ]; then
+    # If a $IG_PEM_TRUSTSTORE is provided, import it into the truststore. Otherwise, do nothing
       CERTS=$(grep 'END CERTIFICATE' $IG_PEM_TRUSTSTORE| wc -l)
       echo "Found (${CERTS}) certificates in $IG_PEM_TRUSTSTORE"
       echo "Importing (${CERTS}) certificates into ${TRUSTSTORE_PATH}"


### PR DESCRIPTION
Change IG_PEM_TRUSTSTORE from being required by the import script, will perform the first import which IG relies on, and then perform further actions if IG_PEM_TRUSTSTORE has a value

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1507