### PR TITLE
1503: Call Test Trusted Directory via internal address

### DIFF
--- a/config/7.3.0/fapi1part2adv/ig/config/dev/config/config.json
+++ b/config/7.3.0/fapi1part2adv/ig/config/dev/config/config.json
@@ -346,7 +346,7 @@
             "name": "Secure API Gateway Test Directory",
             "type": "TrustedDirectory",
             "config": {
-              "directoryJwksUri": "https://&{trusteddir.fqdn}/jwkms/testdirectory/jwks",
+              "directoryJwksUri": "http://test-trusted-directory/jwkms/testdirectory/jwks",
               "issuer": "test-publisher",
               "softwareStatementJwksUriClaimName": "software_jwks_endpoint",
               "softwareStatementOrgIdClaimName": "org_id",

--- a/config/7.3.0/fapi1part2adv/ig/config/prod/config/config.json
+++ b/config/7.3.0/fapi1part2adv/ig/config/prod/config/config.json
@@ -334,7 +334,7 @@
             "name": "Secure API Gateway Test Directory",
             "type": "TrustedDirectory",
             "config": {
-              "directoryJwksUri": "https://&{trusteddir.fqdn}/jwkms/testdirectory/jwks",
+              "directoryJwksUri": "http://test-trusted-directory/jwkms/testdirectory/jwks",
               "issuer": "test-publisher",
               "softwareStatementJwksUriClaimName": "software_jwks_endpoint",
               "softwareStatementOrgIdClaimName": "org_id",


### PR DESCRIPTION
Use the internal k8s service address when SAPI-G access the Test Trusted Directory hosted in the same cluster.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1503