### PR TITLE
1512: Make pass-through route send all traffic to Identity Platform

### DIFF
--- a/config/7.3.0/fapi1part2adv/ig/routes/routes-pod/98-kube-probe.json
+++ b/config/7.3.0/fapi1part2adv/ig/routes/routes-pod/98-kube-probe.json
@@ -1,5 +1,5 @@
 {
-   "name": "Kubernetes endpoints",
+   "name": "98 - Kubernetes endpoints",
    "condition": "${find(request.uri.path, '^/kube')}",
    "handler": {
       "type": "DispatchHandler",

--- a/config/7.3.0/fapi1part2adv/ig/routes/routes-service/99-platform-passthrough.json
+++ b/config/7.3.0/fapi1part2adv/ig/routes/routes-service/99-platform-passthrough.json
@@ -1,8 +1,7 @@
 {
-  "name": "29 - AS pass-through",
-  "comment": "Passthrough for any unprotected AM endpoints (such as the XUI)",
+  "name": "99 - Identity Platform pass-through",
+  "comment": "Pass-through for any unprotected Identity Platform endpoints (such as the XUI) - the name of this route needs to be last alphabetically so that more specific routes can be used if they exist.",
   "baseURI": "https://&{identity.platform.fqdn}",
-  "condition": "${find(request.uri.path, '^/am')}",
   "handler": {
     "type": "Chain",
     "config": {


### PR DESCRIPTION
Rename 29-as-passthrough.json to 99-platform-passthrough.json

The route is now responsible for passing any requests, which have not already been routed, through to the Identity Platform.

This includes AM endpoints such as the XUI and IDM endpoints to fetch config used to render the XUI.

 Fix name of 98-kube-probe.json route to ensure that it is ordered before the pass-through route.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1512