### PR TITLE
1542: Remove auth params from http request for /authorize & /par endpoints

### DIFF
--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/common/jwt/AuthorizeRequestParameterNames.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/common/jwt/AuthorizeRequestParameterNames.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.common.jwt;
+
+public class AuthorizeRequestParameterNames {
+    public final static String  CLIENT_ASSERTION_TYPE = "client_assertion_type";
+    public final static String  CLIENT_ASSERTION = "client_assertion";
+    public final static String CLIENT_ID = "client_id";
+    public final static String REQUEST_URI = "request_uri";
+    public final static String REQUEST = "request";
+}

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/common/jwt/AuthorizeRequestParameterNames.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/common/jwt/AuthorizeRequestParameterNames.java
@@ -22,4 +22,5 @@ public class AuthorizeRequestParameterNames {
     public final static String REQUEST_URI = "request_uri";
     public final static String REQUEST = "request";
     public final static String SCOPE = "scope";
+    public final static String RESPONSE_TYPE = "response_type";
 }

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/common/jwt/AuthorizeRequestParameterNames.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/common/jwt/AuthorizeRequestParameterNames.java
@@ -21,4 +21,5 @@ public class AuthorizeRequestParameterNames {
     public final static String CLIENT_ID = "client_id";
     public final static String REQUEST_URI = "request_uri";
     public final static String REQUEST = "request";
+    public final static String SCOPE = "scope";
 }

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/fapi/v1/authorize/BaseFapiAuthorizeRequestValidationFilter.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/fapi/v1/authorize/BaseFapiAuthorizeRequestValidationFilter.java
@@ -20,6 +20,7 @@ import static com.forgerock.sapi.gateway.common.jwt.AuthorizeRequestParameterNam
 import static com.forgerock.sapi.gateway.common.jwt.AuthorizeRequestParameterNames.CLIENT_ID;
 import static com.forgerock.sapi.gateway.common.jwt.AuthorizeRequestParameterNames.REQUEST;
 import static com.forgerock.sapi.gateway.common.jwt.AuthorizeRequestParameterNames.REQUEST_URI;
+import static com.forgerock.sapi.gateway.common.jwt.AuthorizeRequestParameterNames.RESPONSE_TYPE;
 import static com.forgerock.sapi.gateway.common.jwt.AuthorizeRequestParameterNames.SCOPE;
 
 import java.util.Arrays;
@@ -186,7 +187,8 @@ public abstract class BaseFapiAuthorizeRequestValidationFilter implements Filter
     }
 
     protected Promise<Void, NeverThrowsException> removeParamsFromRequest(Request request) {
-        List<String> allowedParamNames = List.of(CLIENT_ID, CLIENT_ASSERTION, CLIENT_ASSERTION_TYPE, REQUEST_URI, REQUEST, SCOPE);
+        List<String> allowedParamNames = List.of(CLIENT_ID, CLIENT_ASSERTION, CLIENT_ASSERTION_TYPE, REQUEST_URI,
+                REQUEST, SCOPE, RESPONSE_TYPE);
         return removeNonMatchingParamsFromRequest(request, allowedParamNames).thenOnResult((removedParams)->{
             logger.info("Removed {} params from the request", removedParams.size());
         }).thenDiscardResult();

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/fapi/v1/authorize/BaseFapiAuthorizeRequestValidationFilter.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/fapi/v1/authorize/BaseFapiAuthorizeRequestValidationFilter.java
@@ -20,6 +20,7 @@ import static com.forgerock.sapi.gateway.common.jwt.AuthorizeRequestParameterNam
 import static com.forgerock.sapi.gateway.common.jwt.AuthorizeRequestParameterNames.CLIENT_ID;
 import static com.forgerock.sapi.gateway.common.jwt.AuthorizeRequestParameterNames.REQUEST;
 import static com.forgerock.sapi.gateway.common.jwt.AuthorizeRequestParameterNames.REQUEST_URI;
+import static com.forgerock.sapi.gateway.common.jwt.AuthorizeRequestParameterNames.SCOPE;
 
 import java.util.Arrays;
 import java.util.List;
@@ -185,7 +186,7 @@ public abstract class BaseFapiAuthorizeRequestValidationFilter implements Filter
     }
 
     protected Promise<Void, NeverThrowsException> removeParamsFromRequest(Request request) {
-        List<String> allowedParamNames = List.of(CLIENT_ID, CLIENT_ASSERTION, CLIENT_ASSERTION_TYPE, REQUEST_URI, REQUEST);
+        List<String> allowedParamNames = List.of(CLIENT_ID, CLIENT_ASSERTION, CLIENT_ASSERTION_TYPE, REQUEST_URI, REQUEST, SCOPE);
         return removeNonMatchingParamsFromRequest(request, allowedParamNames).thenOnResult((removedParams)->{
             logger.info("Removed {} params from the request", removedParams.size());
         }).thenDiscardResult();

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/fapi/v1/authorize/FapiParRequestValidationFilter.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/fapi/v1/authorize/FapiParRequestValidationFilter.java
@@ -17,6 +17,7 @@ package com.forgerock.sapi.gateway.fapi.v1.authorize;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 import org.forgerock.http.protocol.Form;
@@ -60,21 +61,18 @@ public class FapiParRequestValidationFilter extends BaseFapiAuthorizeRequestVali
             List<String> paramNamesToKeep) {
         return request.getEntity().getFormAsync().then(
                 form -> {
-                    List<String> paramsToRemove = new ArrayList<>();
-                    form.keySet().forEach((formParamKey) -> {
-                        if (!paramNamesToKeep.contains(formParamKey)) {
-                            paramsToRemove.add(formParamKey);
+                    List<String> paramsRemoved = new ArrayList<>();
+                    Iterator<String> itt = form.keySet().iterator();
+                    while(itt.hasNext()){
+                        String key = itt.next();
+                        if(!paramNamesToKeep.contains(key)){
+                            itt.remove();
+                            paramsRemoved.add(key);
+                            logger.debug("Removed form parameter '{}' from PAR request", itt);
                         }
-                    });
-
-                    paramsToRemove.forEach((paramToRemove) -> {
-                        List<String> result = form.remove(paramToRemove);
-                        if (result != null) {
-                            logger.debug("Removed form parameter '{}' from PAR request", paramToRemove);
-                        }
-                    });
+                    }
                     request.setEntity(form);
-                    return paramsToRemove;
+                    return paramsRemoved;
                 }, ioe -> {
                     logger.warn("Failed to remove param from /par request form due to exception", ioe);
                     List<String> emptyList = new ArrayList<>();

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/fapi/v1/authorize/BaseFapiAuthorizeRequestValidationFilterTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/fapi/v1/authorize/BaseFapiAuthorizeRequestValidationFilterTest.java
@@ -54,7 +54,7 @@ public abstract class BaseFapiAuthorizeRequestValidationFilterTest {
 
     protected final BaseFapiAuthorizeRequestValidationFilter filter;
     protected final Context context = new RootContext("test");
-    private final RSASSASigner jwtSigner = new RSASSASigner(CryptoUtils.generateRsaKeyPair().getPrivate());
+    private final JWTSigner jwtSigner = new JWTSigner();
     protected TestSuccessResponseHandler successResponseHandler;
 
     public BaseFapiAuthorizeRequestValidationFilterTest(BaseFapiAuthorizeRequestValidationFilter filter) {
@@ -126,7 +126,7 @@ public abstract class BaseFapiAuthorizeRequestValidationFilterTest {
                 "state", state,
                 "scope", "payments",
                 "response_type", "jwt"));
-        final String signedRequestJwt = createSignedRequestJwt(requestClaims);
+        final String signedRequestJwt = jwtSigner.createSignedRequestJwt(requestClaims);
 
         final Request request = createRequest(signedRequestJwt, state);
         final Promise<Response, NeverThrowsException> responsePromise = filter.filter(context, request, successResponseHandler);
@@ -142,7 +142,7 @@ public abstract class BaseFapiAuthorizeRequestValidationFilterTest {
                 "state", state,
                 "scope", "payments",
                 "response_type", "jwt"));
-        final String signedRequestJwt = createSignedRequestJwt(requestClaims);
+        final String signedRequestJwt = jwtSigner.createSignedRequestJwt(requestClaims);
 
         final Request request = createRequest(signedRequestJwt, state);
         final Promise<Response, NeverThrowsException> responsePromise = filter.filter(context, request, successResponseHandler);
@@ -158,7 +158,7 @@ public abstract class BaseFapiAuthorizeRequestValidationFilterTest {
                 "state", state,
                 "client_id", "client-123",
                 "response_type", "jwt"));
-        final String signedRequestJwt = createSignedRequestJwt(requestClaims);
+        final String signedRequestJwt = jwtSigner.createSignedRequestJwt(requestClaims);
 
         final Request request = createRequest(signedRequestJwt, state);
         final Promise<Response, NeverThrowsException> responsePromise = filter.filter(context, request, successResponseHandler);
@@ -174,7 +174,7 @@ public abstract class BaseFapiAuthorizeRequestValidationFilterTest {
                 "state", state,
                 "client_id", "client-123",
                 "response_type", "jwt"));
-        final String signedRequestJwt = createSignedRequestJwt(requestClaims);
+        final String signedRequestJwt = jwtSigner.createSignedRequestJwt(requestClaims);
 
         final Request request = createRequest(signedRequestJwt, state);
         final Promise<Response, NeverThrowsException> responsePromise = filter.filter(context, request, successResponseHandler);
@@ -190,7 +190,7 @@ public abstract class BaseFapiAuthorizeRequestValidationFilterTest {
                 "nonce", "adsaddas",
                 "state", state,
                 "client_id", "client-123"));
-        final String signedRequestJwt = createSignedRequestJwt(requestClaims);
+        final String signedRequestJwt = jwtSigner.createSignedRequestJwt(requestClaims);
 
         final Request request = createRequest(signedRequestJwt, state);
         final Promise<Response, NeverThrowsException> responsePromise = filter.filter(context, request, successResponseHandler);
@@ -206,7 +206,7 @@ public abstract class BaseFapiAuthorizeRequestValidationFilterTest {
                 "nonce", "adsaddas",
                 "state", state,
                 "client_id", "client-123"));
-        final String signedRequestJwt = createSignedRequestJwt(requestClaims);
+        final String signedRequestJwt = jwtSigner.createSignedRequestJwt(requestClaims);
 
         final Request request = createRequest(signedRequestJwt, state);
         request.getHeaders().add("Accept", HttpMediaTypes.APPLICATION_TEXT);
@@ -228,13 +228,12 @@ public abstract class BaseFapiAuthorizeRequestValidationFilterTest {
                 "state", state,
                 "scope", "openid payments",
                 "response_type", "code id_token"));
-        final String signedRequestJwt = createSignedRequestJwt(requestClaims);
+        final String signedRequestJwt = jwtSigner.createSignedRequestJwt(requestClaims);
 
         final Request request = createRequest(signedRequestJwt, state);
 
         final Promise<Response, NeverThrowsException> responsePromise = filter.filter(context, request, successResponseHandler);
         validateSuccessResponse(responsePromise);
-        validateHandlerReceivedRequestWithStateParam(state);
     }
 
     @Test
@@ -244,7 +243,7 @@ public abstract class BaseFapiAuthorizeRequestValidationFilterTest {
                 "nonce", "sdffdsdfdssfd",
                 "scope", "openid payments",
                 "response_type", "code id_token"));
-        final String signedRequestJwt = createSignedRequestJwt(requestClaims);
+        final String signedRequestJwt = jwtSigner.createSignedRequestJwt(requestClaims);
 
         // state param in URI but NOT in jwt claims
         final Request request = createRequest(signedRequestJwt, "state-12334");
@@ -266,13 +265,12 @@ public abstract class BaseFapiAuthorizeRequestValidationFilterTest {
                 "scope", "openid payments",
                 "response_type", "code",
                 "response_mode", jwtResponseMode));
-        final String signedRequestJwt = createSignedRequestJwt(requestClaims);
+        final String signedRequestJwt = jwtSigner.createSignedRequestJwt(requestClaims);
 
         final Request request = createRequest(signedRequestJwt, state);
 
         final Promise<Response, NeverThrowsException> responsePromise = filter.filter(context, request, successResponseHandler);
         validateSuccessResponse(responsePromise);
-        validateHandlerReceivedRequestWithStateParam(state);
     }
 
     @Test
@@ -284,7 +282,7 @@ public abstract class BaseFapiAuthorizeRequestValidationFilterTest {
                 "state", state,
                 "scope", "openid payments",
                 "response_type", "code"));
-        final String signedRequestJwt = createSignedRequestJwt(requestClaims);
+        final String signedRequestJwt = jwtSigner.createSignedRequestJwt(requestClaims);
 
         final Request request = createRequest(signedRequestJwt, state);
         final Promise<Response, NeverThrowsException> responsePromise = filter.filter(context, request, successResponseHandler);
@@ -302,7 +300,7 @@ public abstract class BaseFapiAuthorizeRequestValidationFilterTest {
                 "scope", "openid payments",
                 "response_type", "code",
                 "response_mode", "not-supported"));
-        final String signedRequestJwt = createSignedRequestJwt(requestClaims);
+        final String signedRequestJwt = jwtSigner.createSignedRequestJwt(requestClaims);
 
         final Request request = createRequest(signedRequestJwt, state);
         final Promise<Response, NeverThrowsException> responsePromise = filter.filter(context, request, successResponseHandler);
@@ -319,7 +317,7 @@ public abstract class BaseFapiAuthorizeRequestValidationFilterTest {
                 "state", state,
                 "scope", "payments",
                 "response_type", "code id_token"));
-        final String signedRequestJwt = createSignedRequestJwt(requestClaims);
+        final String signedRequestJwt = jwtSigner.createSignedRequestJwt(requestClaims);
 
         final Request request = createRequest(signedRequestJwt, state);
         final Promise<Response, NeverThrowsException> responsePromise = filter.filter(context, request, successResponseHandler);
@@ -336,7 +334,7 @@ public abstract class BaseFapiAuthorizeRequestValidationFilterTest {
                 "state", state,
                 "scope", "payments",
                 "response_type", "id_token"));
-        final String signedRequestJwt = createSignedRequestJwt(requestClaims);
+        final String signedRequestJwt = jwtSigner.createSignedRequestJwt(requestClaims);
 
         final Request request = createRequest(signedRequestJwt, state);
         final Promise<Response, NeverThrowsException> responsePromise = filter.filter(context, request, successResponseHandler);
@@ -376,11 +374,5 @@ public abstract class BaseFapiAuthorizeRequestValidationFilterTest {
     protected void validateHandlerReceivedRequestWithoutStateParam() {
         final Request processedRequest = successResponseHandler.getProcessedRequests().get(0);
         assertNull(getRequestState(processedRequest));
-    }
-
-    private String createSignedRequestJwt(JWTClaimsSet claimsSet) throws JOSEException {
-        final SignedJWT signedJWT = new SignedJWT(new Builder(JWSAlgorithm.PS256).keyID("test-kid").build(), claimsSet);
-        signedJWT.sign(jwtSigner);
-        return signedJWT.serialize();
     }
 }

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/fapi/v1/authorize/FapiAuthorizeRequestValidationFilterTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/fapi/v1/authorize/FapiAuthorizeRequestValidationFilterTest.java
@@ -16,6 +16,8 @@
 package com.forgerock.sapi.gateway.fapi.v1.authorize;
 
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 import org.forgerock.http.protocol.Request;
 import org.forgerock.http.protocol.Response;
@@ -25,8 +27,11 @@ import org.forgerock.util.promise.Promise;
 import org.junit.jupiter.api.Test;
 
 import com.forgerock.sapi.gateway.fapi.v1.authorize.FapiAuthorizeRequestValidationFilter.Heaplet;
+import com.nimbusds.jwt.JWTClaimsSet;
 
 class FapiAuthorizeRequestValidationFilterTest extends BaseFapiAuthorizeRequestValidationFilterTest {
+
+    private JWTSigner jwtSigner = new JWTSigner();
 
     FapiAuthorizeRequestValidationFilterTest() throws HeapException {
         super((FapiAuthorizeRequestValidationFilter) new Heaplet().create());
@@ -35,8 +40,11 @@ class FapiAuthorizeRequestValidationFilterTest extends BaseFapiAuthorizeRequestV
     @Test
     void succeedsForAuthorizeRequestsUsingPar() throws Exception {
         // Test calling /authorize with a request_uri of a previously submitted /par request
+        final String state = UUID.randomUUID().toString();
+        final String nonce = UUID.randomUUID().toString();
         final Request request = new Request();
-        request.setUri("https://localhost/am/authorize?request_uri=ref-to-par-req");
+        request.setMethod("GET");
+        request.setUri("https://localhost/am/authorize?request_uri=ref-to-par-req" + "&state=" + state + "&nonce=" + nonce);
         request.setMethod("GET");
 
         final Promise<Response, NeverThrowsException> responsePromise = filter.filter(context, request, successResponseHandler);

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/fapi/v1/authorize/FapiAuthorizeRequestValidationFilterTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/fapi/v1/authorize/FapiAuthorizeRequestValidationFilterTest.java
@@ -31,8 +31,6 @@ import com.nimbusds.jwt.JWTClaimsSet;
 
 class FapiAuthorizeRequestValidationFilterTest extends BaseFapiAuthorizeRequestValidationFilterTest {
 
-    private JWTSigner jwtSigner = new JWTSigner();
-
     FapiAuthorizeRequestValidationFilterTest() throws HeapException {
         super((FapiAuthorizeRequestValidationFilter) new Heaplet().create());
     }

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/fapi/v1/authorize/JWTSigner.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/fapi/v1/authorize/JWTSigner.java
@@ -23,9 +23,19 @@ import com.nimbusds.jose.crypto.RSASSASigner;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 
+/**
+ * Class used to sign a jwt using an RSASASigner initialized with a newly created RSA private key
+ */
 public class JWTSigner {
     private final RSASSASigner jwtSigner = new RSASSASigner(CryptoUtils.generateRsaKeyPair().getPrivate());
 
+    /**
+     * Creates a Signed JWT in the JWS Compact Serialisation format
+     * @see <a href="https://datatracker.ietf.org/doc/html/rfc7515#section-7.1">here</a>
+     * @param claimsSet the claims to be included in the signed jwt
+     * @return a JWS Compact Serialized signed JWT
+     * @throws JOSEException when the jwt can't be signed
+     */
     String createSignedRequestJwt(JWTClaimsSet claimsSet) throws JOSEException {
         final SignedJWT signedJWT = new SignedJWT(new JWSHeader.Builder(JWSAlgorithm.PS256).keyID("test-kid").build(), claimsSet);
         signedJWT.sign(jwtSigner);

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/fapi/v1/authorize/JWTSigner.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/fapi/v1/authorize/JWTSigner.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.fapi.v1.authorize;
+
+import com.forgerock.sapi.gateway.util.CryptoUtils;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+
+public class JWTSigner {
+    private final RSASSASigner jwtSigner = new RSASSASigner(CryptoUtils.generateRsaKeyPair().getPrivate());
+
+    String createSignedRequestJwt(JWTClaimsSet claimsSet) throws JOSEException {
+        final SignedJWT signedJWT = new SignedJWT(new JWSHeader.Builder(JWSAlgorithm.PS256).keyID("test-kid").build(), claimsSet);
+        signedJWT.sign(jwtSigner);
+        return signedJWT.serialize();
+    }
+}


### PR DESCRIPTION
AM doesn't ignore request parameters when a JAR is used for the authorize request as required by RFC 9101. This means we fail some tests in the FAPI 1.0 - Part 2: Advanced + PAR test suite.

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1542