### PR TITLE
1545: Reject PAR with non FAPI PKCE fields in JAR

### DIFF
--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/common/jwt/AuthorizeRequestParameterNames.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/common/jwt/AuthorizeRequestParameterNames.java
@@ -22,5 +22,12 @@ public class AuthorizeRequestParameterNames {
     public final static String REQUEST_URI = "request_uri";
     public final static String REQUEST = "request";
     public final static String SCOPE = "scope";
+    public final static String STATE = "state";
     public final static String RESPONSE_TYPE = "response_type";
+    public final static String RESPONSE_MODE = "response_mode";
+    public final static String REDIRECT_URI = "redirect_uri";
+    public final static String NONCE = "nonce";
+
+    public final static String CODE_CHALLENGE = "code_challenge";
+    public final static String CODE_CHALLENGE_METHOD = "code_challenge_method";
 }

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/fapi/v1/authorize/FapiAuthorizeRequestValidationFilter.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/fapi/v1/authorize/FapiAuthorizeRequestValidationFilter.java
@@ -15,14 +15,22 @@
  */
 package com.forgerock.sapi.gateway.fapi.v1.authorize;
 
+import static com.forgerock.sapi.gateway.common.jwt.AuthorizeRequestParameterNames.CLIENT_ID;
+import static com.forgerock.sapi.gateway.common.jwt.AuthorizeRequestParameterNames.NONCE;
+import static com.forgerock.sapi.gateway.common.jwt.AuthorizeRequestParameterNames.REDIRECT_URI;
+import static com.forgerock.sapi.gateway.common.jwt.AuthorizeRequestParameterNames.RESPONSE_TYPE;
+import static com.forgerock.sapi.gateway.common.jwt.AuthorizeRequestParameterNames.SCOPE;
+
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
 import org.forgerock.http.Handler;
 import org.forgerock.http.protocol.Form;
+import org.forgerock.http.protocol.Header;
 import org.forgerock.http.protocol.Request;
 import org.forgerock.http.protocol.Response;
+import org.forgerock.json.jose.jwt.JwtClaimsSet;
 import org.forgerock.openig.heap.GenericHeaplet;
 import org.forgerock.openig.heap.HeapException;
 import org.forgerock.services.context.Context;
@@ -40,6 +48,8 @@ import org.forgerock.util.promise.Promises;
 public class FapiAuthorizeRequestValidationFilter extends BaseFapiAuthorizeRequestValidationFilter {
 
     private static final String REQUEST_URI_PARAM_NAME = "request_uri";
+    private static final List<String> REQUIRED_REQUEST_JWT_CLAIMS = List.of(SCOPE, NONCE, RESPONSE_TYPE, REDIRECT_URI,
+            CLIENT_ID);
 
     @Override
     public Promise<Response, NeverThrowsException> filter(Context context, Request request, Handler next) {
@@ -77,6 +87,16 @@ public class FapiAuthorizeRequestValidationFilter extends BaseFapiAuthorizeReque
     @Override
     protected Promise<String, NeverThrowsException> getParamFromRequest(Request request, String paramName) {
         return Promises.newResultPromise(getParamFromRequestQuery(request, paramName));
+    }
+
+    @Override
+    protected List<String> getRequiredRequestJwtClaims() {
+        return REQUIRED_REQUEST_JWT_CLAIMS;
+    }
+
+    @Override
+    protected Response checkEndpointSpecificClaims(Header acceptHeader, JwtClaimsSet requestJwtClaimSet) {
+        return null;
     }
 
     /**

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/fapi/v1/authorize/FapiAuthorizeRequestValidationFilterTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/fapi/v1/authorize/FapiAuthorizeRequestValidationFilterTest.java
@@ -15,8 +15,8 @@
  */
 package com.forgerock.sapi.gateway.fapi.v1.authorize;
 
+import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 
 import org.forgerock.http.protocol.Request;
@@ -27,7 +27,6 @@ import org.forgerock.util.promise.Promise;
 import org.junit.jupiter.api.Test;
 
 import com.forgerock.sapi.gateway.fapi.v1.authorize.FapiAuthorizeRequestValidationFilter.Heaplet;
-import com.nimbusds.jwt.JWTClaimsSet;
 
 class FapiAuthorizeRequestValidationFilterTest extends BaseFapiAuthorizeRequestValidationFilterTest {
 
@@ -63,5 +62,10 @@ class FapiAuthorizeRequestValidationFilterTest extends BaseFapiAuthorizeRequestV
     protected String getRequestState(Request request) {
         final List<String> state = request.getQueryParams().get("state");
         return state != null ? state.get(0) : null;
+    }
+
+    @Override
+    protected HashMap<String, Object> getEndpointSpecificMapOfClaims() {
+        return getCommonMapOfClaims();
     }
 }

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/fapi/v1/authorize/FapiParRequestValidationFilterTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/fapi/v1/authorize/FapiParRequestValidationFilterTest.java
@@ -15,16 +15,61 @@
  */
 package com.forgerock.sapi.gateway.fapi.v1.authorize;
 
+import static com.forgerock.sapi.gateway.common.jwt.AuthorizeRequestParameterNames.CODE_CHALLENGE;
+import static com.forgerock.sapi.gateway.common.jwt.AuthorizeRequestParameterNames.CODE_CHALLENGE_METHOD;
+
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.UUID;
 
 import org.forgerock.http.protocol.Form;
 import org.forgerock.http.protocol.Request;
+import org.forgerock.http.protocol.Response;
 import org.forgerock.openig.heap.HeapException;
+import org.forgerock.util.promise.NeverThrowsException;
+import org.forgerock.util.promise.Promise;
+import org.junit.jupiter.api.Test;
+
+import com.nimbusds.jwt.JWTClaimsSet;
 
 class FapiParRequestValidationFilterTest extends BaseFapiAuthorizeRequestValidationFilterTest {
 
+    private JWTSigner jwtSigner = new JWTSigner();
+
+    private String VALID_CODE_CHALLENGE = "SGVsbG8gV29ybGQh";
+    private String VALID_CODE_CHALLENGE_METHOD = "S256";
+
+
     public FapiParRequestValidationFilterTest() throws HeapException {
         super((FapiParRequestValidationFilter) new FapiParRequestValidationFilter.Heaplet().create());
+    }
+
+    @Test
+    void failsForParRequestWithoutPkceCodeChallenge() throws Exception {
+        final String state = UUID.randomUUID().toString();
+        HashMap<String, Object> jarClaims = getEndpointSpecificMapOfClaims();
+        jarClaims.remove(CODE_CHALLENGE);
+        final JWTClaimsSet requestClaims = JWTClaimsSet.parse(jarClaims);
+        final String signedRequestJwt = jwtSigner.createSignedRequestJwt(requestClaims);
+
+        final Request request = createRequest(signedRequestJwt, state);
+
+        final Promise<Response, NeverThrowsException> responsePromise = filter.filter(context, request, successResponseHandler);
+        validateErrorResponse(responsePromise, "Request JWT must have a 'code_challenge' claim");
+    }
+
+    @Test
+    void failsForParRequestWithoutPkceCodeChallengeMethodOfS256() throws Exception {
+        final String state = UUID.randomUUID().toString();
+        HashMap<String, Object> jarClaims = getEndpointSpecificMapOfClaims();
+        jarClaims.put(CODE_CHALLENGE_METHOD, "PS256");
+        final JWTClaimsSet requestClaims = JWTClaimsSet.parse(jarClaims);
+        final String signedRequestJwt = jwtSigner.createSignedRequestJwt(requestClaims);
+
+        final Request request = createRequest(signedRequestJwt, state);
+
+        final Promise<Response, NeverThrowsException> responsePromise = filter.filter(context, request, successResponseHandler);
+        validateErrorResponse(responsePromise, "Request JWT must have a 'code_challenge_method' claim of S256");
     }
 
     @Override
@@ -46,5 +91,19 @@ class FapiParRequestValidationFilterTest extends BaseFapiAuthorizeRequestValidat
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * PAR request requires SCOPE, NONCE, RESPONSE_TYPE, REDIRECT_URI,
+     *             CLIENT_ID, CODE_CHALLENGE, CODE_CHALLENGE_METHOD
+     * @return {@code Map<String, String} containing valid claims for a FAPI 1.0 - Part 2: Advanced compliant PAR
+     * JAR object
+     */
+    @Override
+    protected HashMap<String, Object> getEndpointSpecificMapOfClaims() {
+        HashMap<String, Object> validBaseClaims = getCommonMapOfClaims();
+        validBaseClaims.put(CODE_CHALLENGE, VALID_CODE_CHALLENGE);
+        validBaseClaims.put(CODE_CHALLENGE_METHOD, VALID_CODE_CHALLENGE_METHOD);
+        return validBaseClaims;
     }
 }


### PR DESCRIPTION
Addition and modifications to the AuthorizeRequestValidationFilters such that PAR requests that don't contain the following claims are rejected;  
`code_challenge`
`code_challenge_method`

Furthermore, the `code_challenge_method` claim must be equal to `S256`. This is necessary for FAPI 1.0 - Part 2: Advanced + PAR conformance testing

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1545