### PR TITLE
1602: Build and Deploy SAPIG 4.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     </parent>
 
     <properties>
-        <openig.version>2024.11.0</openig.version>
+        <openig.version>2024.9.0</openig.version>
         <nimbus-jose.version>9.40</nimbus-jose.version>
         <bouncy-castle.version>1.78.1</bouncy-castle.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>


### PR DESCRIPTION
To confirm where the issue lies that we've found when running ob sapig 4.0.0 in the cluster, we are reverting core back to using 2024.9.0 of IG, if it all works okay then we know its something that has changed in OpenIG

To do this, we are changing Core to version 4.0.1

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1602