### PR TITLE
1420: Build V4 OB IG with latest version of Core

### DIFF
--- a/secure-api-gateway-ig-extensions/pom.xml
+++ b/secure-api-gateway-ig-extensions/pom.xml
@@ -57,7 +57,6 @@
         <dependency>
             <groupId>org.forgerock.openig</groupId>
             <artifactId>openig-fapi</artifactId>
-            <scope>provided</scope>
             <exclusions>
                 <exclusion>
                     <groupId>org.checkerframework</groupId>


### PR DESCRIPTION
Remove setting to set openig-fapi as provided

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1620