### PR TITLE
1620: Align core with SAPIG OB UK prod config.json following move to core IG components

### DIFF
--- a/config/7.3.0/fapi1part2adv/ig/config/dev/config/config.json
+++ b/config/7.3.0/fapi1part2adv/ig/config/dev/config/config.json
@@ -311,7 +311,7 @@
       "config": {
         "trustedDirectories": [
           "OpenBankingTestDirectory",
-          "Secure API Gateway Test Directory"
+          "SecureAPIGatewayTestDirectory"
         ]
       }
     },
@@ -346,7 +346,7 @@
       }
     },
     {
-      "name": "Secure API Gateway Test Directory",
+      "name": "SecureAPIGatewayTestDirectory",
       "type": "TrustedDirectory",
       "config": {
         "issuer": "test-publisher",

--- a/config/7.3.0/fapi1part2adv/ig/config/prod/config/config.json
+++ b/config/7.3.0/fapi1part2adv/ig/config/prod/config/config.json
@@ -299,7 +299,7 @@
       "config": {
         "trustedDirectories": [
           "OpenBankingTestDirectory",
-          "Secure API Gateway Test Directory"
+          "SecureAPIGatewayTestDirectory"
         ]
       }
     },
@@ -334,7 +334,7 @@
       }
     },
     {
-      "name": "Secure API Gateway Test Directory",
+      "name": "SecureAPIGatewayTestDirectory",
       "type": "TrustedDirectory",
       "config": {
         "issuer": "test-publisher",


### PR DESCRIPTION
1620: Align core with SAPIG OB UK prod config.json following move to core IG components (openig-fapi)

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1620