### PR TITLE
OPENIG-8856: Consume FAPI-enabled IG standalone deliverable (image)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
             <dependency>
                 <groupId>org.forgerock.openig</groupId>
                 <artifactId>openig-bom</artifactId>
-                <version>${openig.version}</version>
+                <version>${openig.version} </version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
             <dependency>
                 <groupId>org.forgerock.openig</groupId>
                 <artifactId>openig-bom</artifactId>
-                <version>${openig.version} </version>
+                <version>${openig.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     </parent>
 
     <properties>
-        <openig.version>2024.11.0</openig.version>
+        <openig.version>2025.3.0-SNAPSHOT</openig.version>
         <nimbus-jose.version>9.40</nimbus-jose.version>
         <bouncy-castle.version>1.78.1</bouncy-castle.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
@@ -61,11 +61,6 @@
                 <version>${openig.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
-            </dependency>
-            <dependency>
-                <groupId>org.forgerock.openig</groupId>
-                <artifactId>openig-fapi</artifactId>
-                <version>${openig.version}</version>
             </dependency>
             <!-- Third party -->
             <dependency>

--- a/secure-api-gateway-core-docker/Dockerfile
+++ b/secure-api-gateway-core-docker/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-ARG base_image=gcr.io/forgerock-io/ig/docker-build:latest-fapi
+ARG base_image=gcr.io/forgerock-io/ig/docker-build:latest-postcommit-fapi
 
 FROM ${base_image}
 # Switching back to forgerock user, app will run as this

--- a/secure-api-gateway-core-docker/Dockerfile
+++ b/secure-api-gateway-core-docker/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-ARG base_image=gcr.io/forgerock-io/ig/docker-build:latest-postcommit-fapi
+ARG base_image=gcr.io/forgerock-io/ig/docker-build:2025.3.0-latest-postcommit-fapi
 
 FROM ${base_image}
 # Switching back to forgerock user, app will run as this

--- a/secure-api-gateway-core-docker/Dockerfile
+++ b/secure-api-gateway-core-docker/Dockerfile
@@ -14,7 +14,8 @@
 # limitations under the License.
 #
 
-ARG base_image=gcr.io/forgerock-io/ig:2025.3.0-latest-fapi
+ARG base_image=gcr.io/forgerock-io/ig/docker-build:latest-fapi
+
 FROM ${base_image}
 # Switching back to forgerock user, app will run as this
 USER forgerock

--- a/secure-api-gateway-core-docker/Dockerfile
+++ b/secure-api-gateway-core-docker/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-ARG base_image=gcr.io/forgerock-io/ig:2024.11.0
+ARG base_image=gcr.io/forgerock-io/ig:2025.3.0-latest-fapi
 FROM ${base_image}
 # Switching back to forgerock user, app will run as this
 USER forgerock

--- a/secure-api-gateway-core-docker/pom.xml
+++ b/secure-api-gateway-core-docker/pom.xml
@@ -43,21 +43,6 @@
             <artifactId>bcpkix-jdk18on</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.openig</groupId>
-            <artifactId>openig-fapi</artifactId>
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.checkerframework</groupId>
-                    <artifactId>checker-qual</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.google.errorprone</groupId>
-                    <artifactId>error_prone_annotations</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
         </dependency>

--- a/secure-api-gateway-ig-extensions/pom.xml
+++ b/secure-api-gateway-ig-extensions/pom.xml
@@ -31,8 +31,26 @@
 
     <properties>
         <legal.path.header>../legal/LICENSE-HEADER.txt</legal.path.header>
+        <logback.version>1.5.16</logback.version>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <!-- Force ${logback.version} used by IG 2025.3, as spring-boot-dependencies uses 1.4.14 -->
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-core</artifactId>
+                <version>${logback.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>${logback.version}</version>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.forgerock.openig</groupId>
@@ -57,16 +75,7 @@
         <dependency>
             <groupId>org.forgerock.openig</groupId>
             <artifactId>openig-fapi</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.checkerframework</groupId>
-                    <artifactId>checker-qual</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.google.errorprone</groupId>
-                    <artifactId>error_prone_annotations</artifactId>
-                </exclusion>
-            </exclusions>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.nimbusds</groupId>
@@ -87,6 +96,11 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>


### PR DESCRIPTION
OPENIG-8856: Include openig-fapi in core IG standalone deliverable, to be picked up in SAPIG-core.

Test IG FAPI-enabled image deployment (removing explicit dependency on IG's openig-fapi module).