### PR TITLE
1650: Investigate why IG is calling to TTD on start up

### DIFF
--- a/config/7.3.0/fapi1part2adv/ig/config/dev/config/config.json
+++ b/config/7.3.0/fapi1part2adv/ig/config/dev/config/config.json
@@ -310,8 +310,7 @@
       "type": "TrustedDirectoryService",
       "config": {
         "trustedDirectories": [
-          "OpenBankingTestDirectory",
-          "SecureAPIGatewayTestDirectory"
+          "OpenBankingTestDirectory"
         ]
       }
     },

--- a/config/7.3.0/fapi1part2adv/ig/config/prod/config/config.json
+++ b/config/7.3.0/fapi1part2adv/ig/config/prod/config/config.json
@@ -298,8 +298,7 @@
       "type": "TrustedDirectoryService",
       "config": {
         "trustedDirectories": [
-          "OpenBankingTestDirectory",
-          "SecureAPIGatewayTestDirectory"
+          "OpenBankingTestDirectory"
         ]
       }
     },


### PR DESCRIPTION
Remove SecureAPIGatewayTestDirectory from trustedDirs

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1650