### PR TITLE
OPENIG-9142 Change CachingJwkSetService to use VerificationKey purpose.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     </parent>
 
     <properties>
-        <openig.version>2025.3.0-SNAPSHOT</openig.version>
+        <openig.version>2025.6.0-SNAPSHOT</openig.version>
         <nimbus-jose.version>9.40</nimbus-jose.version>
         <bouncy-castle.version>1.78.1</bouncy-castle.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/mtls/TransportCertValidator.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/mtls/TransportCertValidator.java
@@ -17,11 +17,8 @@ package com.forgerock.sapi.gateway.mtls;
 
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import java.util.stream.Stream;
 
-import org.forgerock.json.jose.jwk.JWKSet;
 import org.forgerock.secrets.jwkset.JwkSetSecretStore;
-import org.forgerock.secrets.keys.CertificateVerificationKey;
 import org.forgerock.util.promise.Promise;
 
 /**

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/mtls/DefaultTransportCertValidatorTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/mtls/DefaultTransportCertValidatorTest.java
@@ -41,7 +41,7 @@ import org.forgerock.openig.heap.HeapImpl;
 import org.forgerock.openig.heap.Name;
 import org.forgerock.secrets.Purpose;
 import org.forgerock.secrets.jwkset.JwkSetSecretStore;
-import org.forgerock.secrets.keys.CertificateVerificationKey;
+import org.forgerock.secrets.keys.VerificationKey;
 import org.forgerock.util.Options;
 import org.forgerock.util.Pair;
 import org.junit.jupiter.api.BeforeAll;
@@ -62,8 +62,8 @@ class DefaultTransportCertValidatorTest {
     // The transport cert JWK's keyUse, and related purpose
     private static final String TRANSPORT_CERT_KEY_USE = "tls";
     private static final String TRANSPORT_CERT_LABEL = "tls";
-    private static final Purpose<CertificateVerificationKey> TRANSPORT_CERT_PURPOSE =
-            purpose(TRANSPORT_CERT_LABEL, CertificateVerificationKey.class);
+    private static final Purpose<VerificationKey> TRANSPORT_CERT_PURPOSE =
+            purpose(TRANSPORT_CERT_LABEL, VerificationKey.class);
 
     // It's easier to use a real JwkSetSecretStore
     private static JwkSetSecretStore jwkSetSecretStore;
@@ -94,10 +94,10 @@ class DefaultTransportCertValidatorTest {
                 // Validator configured to use TLS transport purpose as expected transport cert purpose
                 new DefaultTransportCertValidator(TRANSPORT_CERT_PURPOSE),
                 // Specified, but uninteresting, purpose
-                new DefaultTransportCertValidator(purpose("label", CertificateVerificationKey.class)),
+                new DefaultTransportCertValidator(purpose("label", VerificationKey.class)),
                 // Non-specific purpose defaults to "verify"
                 new DefaultTransportCertValidator(purpose(Purpose.VERIFY_CERTIFICATE.getLabel(),
-                                                          CertificateVerificationKey.class))
+                                                          VerificationKey.class))
         );
     }
 

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/mtls/ResponsePathTransportCertValidationFilterTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/mtls/ResponsePathTransportCertValidationFilterTest.java
@@ -51,7 +51,7 @@ import org.forgerock.openig.heap.Heaplet;
 import org.forgerock.openig.heap.Name;
 import org.forgerock.secrets.Purpose;
 import org.forgerock.secrets.jwkset.JwkSetSecretStore;
-import org.forgerock.secrets.keys.CertificateVerificationKey;
+import org.forgerock.secrets.keys.VerificationKey;
 import org.forgerock.services.context.AttributesContext;
 import org.forgerock.services.context.RootContext;
 import org.forgerock.util.Options;
@@ -81,8 +81,8 @@ public class ResponsePathTransportCertValidationFilterTest {
     // The transport cert JWK's keyUse, and related purpose
     private static final String TRANSPORT_CERT_KEY_USE = "tls";
     private static final String TRANSPORT_CERT_LABEL = "tls";
-    private static final Purpose<CertificateVerificationKey> TRANSPORT_CERT_PURPOSE =
-            purpose(TRANSPORT_CERT_LABEL, CertificateVerificationKey.class);
+    private static final Purpose<VerificationKey> TRANSPORT_CERT_PURPOSE =
+            purpose(TRANSPORT_CERT_LABEL, VerificationKey.class);
 
     // It's easier to use a real JwkSetSecretStore
     private static JwkSetSecretStore jwkSetSecretStore;


### PR DESCRIPTION
Update following COMMONS fix to use VerificationKey for "tls' use.

Update propagated through OPENIG-9142 in IG repo.

IG PR: https://stash.forgerock.org/projects/OPENIG/repos/openig/pull-requests/6723/overview
COMMONS: https://stash.forgerock.org/projects/COMMONS/repos/forgerock-commons/pull-requests/2670/builds