### PR TITLE
OPENIG-9142 Fix ProcessRegistration transport cert validation

### DIFF
--- a/config/7.3.0/fapi1part2adv/ig/routes/routes-service/20-as-dcr-endpoint.json
+++ b/config/7.3.0/fapi1part2adv/ig/routes/routes-service/20-as-dcr-endpoint.json
@@ -65,6 +65,7 @@
             "file": "ProcessRegistration.groovy",
             "args": {
               "jwkSetService": "${heap['JwkSetService']}",
+              "tlsTransportCertSecretId": "&{security.tlsTransportCertSecretId}",
               "allowIgIssuedTestCerts": "${security.enableTestTrustedDirectory}",
               "jwtSignatureValidator": "${heap['RsaJwtSignatureValidator']}",
               "tokenEndpointAuthMethodsSupported": "${oauth2.tokenEndpointAuthMethodsSupported}",


### PR DESCRIPTION
Fixes:
1. Fix `ProcessRegistration` transport cert validation (should use configured "tls" purpose). Added new `ProcessRegistraton` script config item `tlsTransportCertSecretId` allowing us to now pass the purpose label in (corresponding with where it's used elsewhere. This was broken with changes in the IG PR.
2. Fixed failing core test `FapiDynamicClientRegistrationTest.MtlsTests#MtlsTests` caused because the `#getValid` call allows no secrets to be supplied (which I now have to convert to my own `NSSE`).
3. Fixed failing core test `FapiDynamicClientRegistrationTest.RequestJwtSigningTests#failsIfRequestJwtSignedByKeyWithIncorrectUse()` [failure](https://g.codefresh.io/build/67e12e478c6d39b1d888dbc8?activeAccountId=5bc76f3a8249cc15fa883acb&step=run_tests&tab=output&logs=terminal), caused by key (JWK) "use" not being checked. Fixed in line with how this is now handled for "tls" key use.
4. Other small fixes and improvements

Linked IG PR, including fix for "sig" failure: [OPENIG/openig#6734](https://stash.forgerock.org/projects/OPENIG/repos/openig/pull-requests/6734/overview)