### PR TITLE
1670: Move Kustomize base templates to individual repos

### DIFF
--- a/_infra/kustomize/base/configmap.yaml
+++ b/_infra/kustomize/base/configmap.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: core-deployment-config
+data:
+  #--Fully Qualified Domain Names--
+  BASE_FQDN: "dev.forgerock.financial"
+  IDENTITY_PLATFORM_FQDN: "iam.dev.forgerock.financial"
+  IG_FQDN: "sapig.dev.forgerock.financial"
+  MTLS_FQDN: "mtls.sapig.dev.forgerock.financial"
+  TRUSTEDDIR_FQDN: "test-trusted-directory.dev.forgerock.financial"
+  # --Environment Settings for SAPIG & Cloud Platform--
+  # ---SAPIG---
+  # core: base sapig
+  # ob: Open Banking specification of sapig
+  SAPIG_TYPE: "core"
+  # ---Cloud---
+  # CDK value: (Cloud Developer's Kit) development identity platform
+  # CDM value: CDM (Cloud Deployment Model)
+  # FIDC value: FIDC (Forgerock Identity Cloud) identity cloud platform
+  CLOUD_TYPE: "CDK"
+  #--Additional Config--
+  AM_REALM: "alpha"
+  CERT_ISSUER: "null-issuer" #Needed?
+  # Connection settings for the IG hosted data repo
+  GATEWAY_DATA_REPO_URI: "http://ig:80" # Needed for RCS and RS
+  # Wherever to use additional TTD other than OB
+  IG_TEST_DIRECTORY_ENABLED: "true"
+  # Where to store the IG Truststore
+  IG_TRUSTSTORE_PATH: "/secrets/truststore/igtruststore"
+  USER_OBJECT: "user"

--- a/_infra/kustomize/base/deployment.yaml
+++ b/_infra/kustomize/base/deployment.yaml
@@ -1,0 +1,106 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: ig
+    app.kubernetes.io/component: ig
+    app.kubernetes.io/instance: ig
+    app.kubernetes.io/part-of: pingid
+    tier: middle
+  name: ig
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ig
+      app.kubernetes.io/component: ig
+      app.kubernetes.io/instance: ig
+      app.kubernetes.io/part-of: pingid
+      tier: middle
+  template:
+    metadata:
+      labels:
+        app: ig
+        app.kubernetes.io/component: ig
+        app.kubernetes.io/instance: ig
+        app.kubernetes.io/part-of: pingid
+        tier: middle
+    spec:
+      containers:
+        - env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          envFrom:
+            - secretRef:
+                name: core-secrets
+            - configMapRef:
+                name: core-deployment-config
+          image: ig
+          imagePullPolicy: Always
+          livenessProbe:
+            httpGet:
+              path: /kube/liveness
+              port: 8080
+            periodSeconds: 30
+            timeoutSeconds: 5
+          name: ig
+          ports:
+            - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /kube/readiness
+              port: 8080
+            initialDelaySeconds: 5
+          resources:
+            limits:
+              memory: 512Mi
+            requests:
+              cpu: 200m
+              memory: 512Mi
+          volumeMounts:
+            - mountPath: /var/ig/secrets/truststore
+              name: new-truststore
+              readOnly: true
+      initContainers:
+        - command:
+            - /home/forgerock/import-pem-certs.sh
+          env:
+            - name: TRUSTSTORE_PATH
+              value: /truststore/igtruststore
+            - name: TRUSTSTORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: IG_TRUSTSTORE_PASSWORD
+                  name: core-secrets
+            - name: IG_PEM_TRUSTSTORE
+              value: /var/run/secrets/truststore/ig-truststore.pem
+          image: ig
+          imagePullPolicy: Always
+          name: truststore-init
+          volumeMounts:
+            - mountPath: /truststore
+              name: new-truststore
+            - mountPath: /var/run/secrets/truststore
+              name: ig-truststore-pem
+      securityContext:
+        runAsGroup: 0
+        runAsUser: 11111
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Exists
+      volumes:
+        - emptyDir: {}
+          name: new-truststore
+        - name: ig-truststore-pem
+          secret:
+            optional: false
+            secretName: ig-truststore-pem

--- a/_infra/kustomize/base/ingress.yaml
+++ b/_infra/kustomize/base/ingress.yaml
@@ -1,0 +1,113 @@
+# Ingress for routes requiring MTLS with Open Banking Directory issued certs
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: "true"
+    nginx.ingress.kubernetes.io/auth-tls-secret: NAMESPACE_PLACEHOLDER/mtls-ca-certs
+    nginx.ingress.kubernetes.io/auth-tls-verify-client: optional_no_ca
+    nginx.ingress.kubernetes.io/large-client-header-buffers: "4 128k"
+    nginx.ingress.kubernetes.io/proxy-body-size: 64m
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
+    nginx.ingress.kubernetes.io/proxy-buffers: 4 256k
+    nginx.ingress.kubernetes.io/proxy-busy-buffers_size: 256k
+    nginx.ingress.kubernetes.io/error-log-level: "debug"
+  name: mtls
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: MTLS_FQDN_PLACEHOLDER
+      http:
+        paths:
+          - backend:
+              service:
+                name: ig
+                port:
+                  number: 80
+            path: /am/oauth2/realms/root/realms/alpha/access_token
+            pathType: Exact
+          - backend:
+              service:
+                name: ig
+                port:
+                  number: 80
+            path: /am/oauth2/realms/root/realms/alpha/register
+            pathType: Prefix
+          - backend:
+              service:
+                name: ig
+                port:
+                  number: 80
+            path: /am/oauth2/realms/root/realms/alpha/par
+            pathType: Prefix
+          - backend:
+              service:
+                name: ig
+                port:
+                  number: 80
+            path: /rs/
+            pathType: Prefix
+  tls:
+    - hosts:
+        - MTLS_FQDN_PLACEHOLDER
+      secretName: mtls-tls-cert
+---
+# Ingress for access to routes protected with TLS by a ForgeRock cert
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/large-client-header-buffers: "4 128k"
+    nginx.ingress.kubernetes.io/proxy-body-size: 64m
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
+    nginx.ingress.kubernetes.io/proxy-buffers: 4 256k
+    nginx.ingress.kubernetes.io/proxy-busy-buffers_size: 256k
+    nginx.ingress.kubernetes.io/error-log-level: "debug"
+  name: sapig
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: FQDN_PLACEHOLDER
+      http:
+        paths:
+          - backend:
+              service:
+                name: ig
+                port:
+                  number: 80
+            path: /
+            pathType: Prefix
+  tls:
+    - hosts:
+        - FQDN_PLACEHOLDER
+      secretName: sapig-tls-cert
+---
+# Ingress for dev only, provides access to the IG Studio UI
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ig-web
+  annotations:
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: "/$2"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - FQDN_PLACEHOLDER
+      secretName: sapig-tls-cert
+  rules:
+    - host: FQDN_PLACEHOLDER
+      http:
+        paths:
+          - backend:
+              service:
+                name: ig
+                port:
+                  number: 80
+            path: /ig(/|$)(.*)
+            pathType: ImplementationSpecific

--- a/_infra/kustomize/base/kustomization.yaml
+++ b/_infra/kustomize/base/kustomization.yaml
@@ -1,0 +1,12 @@
+generatorOptions:
+  disableNameSuffixHash: true
+labels:
+  - includeSelectors: true
+    pairs:
+      app.kubernetes.io/name: pingid
+resources:
+  - configmap.yaml
+  - deployment.yaml
+  - ingress.yaml
+  - secret.yaml
+  - service.yaml

--- a/_infra/kustomize/base/secret.yaml
+++ b/_infra/kustomize/base/secret.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: core-secrets
+type: Opaque
+data:
+  # IG_AGENT_ID: aWctYWdlbnQ=
+  # IG_AGENT_PASSWORD: cGFzc3dvcmQ=
+  # IG_CLIENT_ID: aWctY2xpZW50
+  # IG_CLIENT_SECRET: cGFzc3dvcmQ=
+  # IG_IDM_USER: c2VydmljZV9hY2NvdW50Lmln
+  # IG_IDM_PASSWORD: MHBlbkJhbmtpbmch
+  # IG_METRICS_USERNAME: dXNlcg==
+  # IG_METRICS_PASSWORD: cGFzc3dvcmQ=
+  # IG_TRUSTSTORE_PASSWORD: Y2hhbmdlaXQ=

--- a/_infra/kustomize/base/service.yaml
+++ b/_infra/kustomize/base/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ig
+spec:
+  ports:
+    - name: ig
+      port: 80
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app: ig
+  type: ClusterIP


### PR DESCRIPTION
- Add kustomize base templates to repo, so that the overlays can call this location instead of going through multiple base repositories
- Also gives further control over names for future work

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1670