### PR TITLE
OPENIG-9340 OB request scope validator (post-2025.6)

### DIFF
--- a/config/7.3.0/fapi1part2adv/ig/routes/routes-service/20-as-dcr-endpoint.json
+++ b/config/7.3.0/fapi1part2adv/ig/routes/routes-service/20-as-dcr-endpoint.json
@@ -25,6 +25,11 @@
           }
         },
         {
+          "comment": "FAPI/ OB Scope validation versus SSA",
+          "name": "scopeValidationFilter",
+          "type": "RegistrationRequestRoleBasedScopeValidationFilter"
+        },
+        {
           "name": "AddIgAccessTokenForNewRegistrations",
           "comment": "When creating a new registration we need to obtain credentials to allow IG to talk to AM. For flows which operate on an existing registration, the TPP must supply the registration_access_token returned in the DCR response",
           "type": "ConditionalFilter",

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/SecureApiGatewayClassAliasResolver.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/SecureApiGatewayClassAliasResolver.java
@@ -23,14 +23,17 @@ import org.forgerock.openig.alias.ClassAliasResolver;
 import com.forgerock.sapi.gateway.am.AccessTokenResponseIdTokenReSignFilter;
 import com.forgerock.sapi.gateway.am.AuthorizeResponseJwtReSignFilter;
 import com.forgerock.sapi.gateway.am.JwtReSigner;
+import com.forgerock.sapi.gateway.dcr.filter.RegistrationRequestRoleBasedScopeValidationFilter;
 
 public class SecureApiGatewayClassAliasResolver implements ClassAliasResolver {
     private static final Map<String, Class<?>> ALIASES = new HashMap<>();
 
     static {
-        ALIASES.put("JwtReSigner", JwtReSigner.class);
         ALIASES.put("AccessTokenResponseIdTokenReSignFilter", AccessTokenResponseIdTokenReSignFilter.class);
         ALIASES.put("AuthorizeResponseJwtReSignFilter", AuthorizeResponseJwtReSignFilter.class);
+        ALIASES.put("JwtReSigner", JwtReSigner.class);
+        ALIASES.put("RegistrationRequestRoleBasedScopeValidationFilter",
+                    RegistrationRequestRoleBasedScopeValidationFilter.Heaplet.class);
     }
 
     /**

--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/filter/RegistrationRequestRoleBasedScopeValidationFilter.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/dcr/filter/RegistrationRequestRoleBasedScopeValidationFilter.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.dcr.filter;
+
+import static org.forgerock.http.protocol.Response.newResponsePromise;
+import static org.forgerock.openig.fapi.dcr.common.ErrorCode.INVALID_CLIENT_METADATA;
+import static org.forgerock.openig.fapi.dcr.common.ErrorCode.INVALID_SOFTWARE_STATEMENT;
+import static org.forgerock.openig.fapi.error.ErrorResponseUtils.errorResponse;
+import static org.forgerock.util.promise.Promises.newExceptionPromise;
+import static org.forgerock.util.promise.Promises.newVoidResultPromise;
+
+import java.util.List;
+
+import org.forgerock.http.Filter;
+import org.forgerock.http.Handler;
+import org.forgerock.http.protocol.Request;
+import org.forgerock.http.protocol.Response;
+import org.forgerock.openig.fapi.dcr.request.RegistrationRequest;
+import org.forgerock.openig.fapi.dcr.request.RegistrationRequestException;
+import org.forgerock.openig.fapi.dcr.request.RegistrationRequestFapiContext;
+import org.forgerock.openig.heap.GenericHeaplet;
+import org.forgerock.openig.heap.HeapException;
+import org.forgerock.services.context.Context;
+import org.forgerock.util.promise.NeverThrowsException;
+import org.forgerock.util.promise.Promise;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This {@link RegistrationRequestRoleBasedScopeValidationFilter} enforces registration scope validation by cross-reference
+ * of permitted SSA roles.
+ *
+ * <p>Note that this scope validation is based around <i>Open Banking scope validation</i>, not strictly FAPI, for which
+ * there are no specific scope validation roles. For backward compatibility support, we continue to support this form of
+ * scope validation. Note that this will eventually be moved to the Open Banking-specific codebase.
+ *
+ * <p><i>As such, this class should not be used outside Ping-managed configuration.</i>
+ *
+ * <p>This {@link RegistrationRequestRoleBasedScopeValidationFilter} enforces the OBIE
+ * <a href="https://openbankinguk.github.io/dcr-docs-pub/v3.3/dynamic-client-registration.html#data-mapping">
+ *     dynamic client registration scope rule</a>, stating
+ * <pre>
+ * "scope: Specified in the scope claimed. This must be a subset of the scopes in the SSA"
+ * </pre>
+ *
+ * <p>Note also that the
+ * <a href=
+ * "https://openbankinguk.github.io/dcr-docs-pub/v3.3/dynamic-client-registration.html#obclientregistrationrequest1">
+ * data dictionary for OBClientRegistrationRequest1 </a>
+ * states that:
+ * <pre>
+ *   scope     1..1     scope     Scopes the client is asking for (if not specified, default scopes are assigned by
+ *   the AS). This consists of a list scopes separated by spaces.     String(256)
+ * </pre>
+ *
+ * <p>In the Open Banking issued SSA we can find no scopes defined, however, we do have 'software_roles' which is an
+ * array of strings containing AISP, PISP, or a subset thereof, or ASPSP. We must check that the scopes requested are
+ * allowed according to the roles defined in the software statement.
+ *
+ */
+public class RegistrationRequestRoleBasedScopeValidationFilter implements Filter {
+
+    private static final Logger logger =
+            LoggerFactory.getLogger(RegistrationRequestRoleBasedScopeValidationFilter.class);
+
+    static final String ROLE_AISP = "AISP";
+    static final String ROLE_CBPII = "CBPII";
+    static final String ROLE_PISP = "PISP";
+    static final String SCOPE_ACCOUNTS = "accounts";
+    static final String SCOPE_FUNDS = "fundsconformations";
+    static final String SCOPE_PAYMENTS = "payments";
+
+    @Override
+    public Promise<Response, NeverThrowsException> filter(final Context context,
+                                                          final Request request,
+                                                          final Handler next) {
+        RegistrationRequest registrationRequest = context.asContext(RegistrationRequestFapiContext.class)
+                                                         .getRegistrationRequest();
+        return validate(registrationRequest)
+                .thenAsync(ignored -> next.handle(context, request),
+                           registrationException ->
+                                   newResponsePromise(errorResponse(registrationException)));
+    }
+
+    private Promise<Void, RegistrationRequestException> validate(final RegistrationRequest registrationRequest) {
+        String requestedScopes = registrationRequest.getScope();
+        if (requestedScopes == null) {
+            return newExceptionPromise(
+                    new RegistrationRequestException(INVALID_CLIENT_METADATA,
+                                                     "The request jwt does not contain the required scopes claim"));
+        }
+        List<String> ssaRoles = registrationRequest.getSoftwareStatement().getRoles();
+        if (ssaRoles.isEmpty()) {
+            return newExceptionPromise(new RegistrationRequestException(
+                    INVALID_SOFTWARE_STATEMENT,
+                    "The software_statement jwt does not contain a 'software_roles' claim"));
+        }
+        logger.debug("requestedScopes: {}, SSA roles: {}\"", requestedScopes, ssaRoles);
+
+        if (requestedScopes.contains(SCOPE_ACCOUNTS) && !ssaRoles.contains(ROLE_AISP)) {
+            String error = ("registration request contains scopes (%s) not allowed "
+                    + "for the presented software statement (%s)").formatted(SCOPE_ACCOUNTS, ROLE_AISP);
+            return newExceptionPromise(new RegistrationRequestException(INVALID_CLIENT_METADATA, error));
+        }
+        if (requestedScopes.contains(SCOPE_PAYMENTS) && !ssaRoles.contains(ROLE_PISP)) {
+            String error = ("registration request contains scopes (%s) not allowed "
+                    + "for the presented software statement (%s)").formatted(SCOPE_PAYMENTS, ROLE_PISP);
+            return newExceptionPromise(new RegistrationRequestException(INVALID_CLIENT_METADATA, error));
+        }
+        if (requestedScopes.contains(SCOPE_FUNDS) && !ssaRoles.contains(ROLE_CBPII)) {
+            String error = ("registration request contains scopes (%s) not allowed "
+                    + "for the presented software statement (%s)").formatted(SCOPE_FUNDS, ROLE_CBPII);
+            return newExceptionPromise(new RegistrationRequestException(INVALID_CLIENT_METADATA, error));
+        }
+        logger.debug("Open Banking scopes valid");
+        return newVoidResultPromise();
+    }
+
+    /**
+     * Create a {@link RegistrationRequestRoleBasedScopeValidationFilter} in a heap environment.
+     */
+    public static class Heaplet extends GenericHeaplet {
+        @Override
+        public Object create() throws HeapException {
+            return new RegistrationRequestRoleBasedScopeValidationFilter();
+        }
+    }
+}

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/filter/RegistrationRequestRoleBasedScopeValidationFilterTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/dcr/filter/RegistrationRequestRoleBasedScopeValidationFilterTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.dcr.filter;
+
+import static com.forgerock.sapi.gateway.dcr.filter.RegistrationRequestRoleBasedScopeValidationFilter.ROLE_AISP;
+import static com.forgerock.sapi.gateway.dcr.filter.RegistrationRequestRoleBasedScopeValidationFilter.ROLE_CBPII;
+import static com.forgerock.sapi.gateway.dcr.filter.RegistrationRequestRoleBasedScopeValidationFilter.ROLE_PISP;
+import static com.forgerock.sapi.gateway.dcr.filter.RegistrationRequestRoleBasedScopeValidationFilter.SCOPE_ACCOUNTS;
+import static com.forgerock.sapi.gateway.dcr.filter.RegistrationRequestRoleBasedScopeValidationFilter.SCOPE_FUNDS;
+import static com.forgerock.sapi.gateway.dcr.filter.RegistrationRequestRoleBasedScopeValidationFilter.SCOPE_PAYMENTS;
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
+import static org.forgerock.http.protocol.Response.newResponsePromise;
+import static org.forgerock.http.protocol.Status.OK;
+import static org.forgerock.json.JsonValue.json;
+import static org.forgerock.openig.fapi.dcr.common.ErrorCode.INVALID_CLIENT_METADATA;
+import static org.forgerock.openig.fapi.dcr.common.ErrorCode.INVALID_SOFTWARE_STATEMENT;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.forgerock.http.Filter;
+import org.forgerock.http.Handler;
+import org.forgerock.http.protocol.Request;
+import org.forgerock.http.protocol.Response;
+import org.forgerock.json.JsonValue;
+import org.forgerock.openig.fapi.dcr.SoftwareStatement;
+import org.forgerock.openig.fapi.dcr.common.ErrorCode;
+import org.forgerock.openig.fapi.dcr.request.RegistrationRequest;
+import org.forgerock.openig.fapi.dcr.request.RegistrationRequestFapiContext;
+import org.forgerock.services.context.Context;
+import org.forgerock.services.context.RootContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RegistrationRequestRoleBasedScopeValidationFilterTest {
+
+    @Mock
+    private RegistrationRequest mockRegistrationRequest;
+    @Mock
+    private SoftwareStatement softwareStatement;
+    @Mock
+    Handler next;
+    private final Filter scopeValidationFilter = new RegistrationRequestRoleBasedScopeValidationFilter();
+    private Context context;
+    private Request request;
+
+    static Stream<Arguments> validScopesAndSsaRoles() {
+        return Stream.of(
+                // Payments scope, where SSA has PISP (payments) role
+                arguments(List.of(SCOPE_PAYMENTS),
+                          List.of(ROLE_AISP, ROLE_PISP)),
+                // Accounts scope, where SSA has AISP (accounts) role
+                arguments(List.of(SCOPE_ACCOUNTS),
+                          List.of(ROLE_AISP, ROLE_PISP)),
+                // Funds scope, where SSA has CBPII (funds) role
+                arguments(List.of(SCOPE_FUNDS),
+                          List.of(ROLE_CBPII, ROLE_PISP)));
+    }
+
+    @BeforeEach
+    void setUp() {
+        context = new RegistrationRequestFapiContext(new RootContext(), mockRegistrationRequest);
+        request = new Request().setMethod("POST");
+    }
+
+    @ParameterizedTest
+    @MethodSource("validScopesAndSsaRoles")
+    void shouldValidateScopesAndSsaRoles(final List<String> scopes, final List<String> ssaRoles) {
+        //Given
+        when(mockRegistrationRequest.getScope()).thenReturn(String.join(" ", scopes));
+        when(mockRegistrationRequest.getSoftwareStatement()).thenReturn(softwareStatement);
+        when(softwareStatement.getRoles()).thenReturn(ssaRoles);
+        when(next.handle(context, request)).thenReturn(newResponsePromise(new Response(OK)));
+        // When/ Then
+        Response response = scopeValidationFilter.filter(context, request, next).getOrThrowIfInterrupted();
+        assertThat(response.getStatus()).isEqualTo(OK);
+    }
+
+    static Stream<Arguments> invalidScopesAndSsaRoles() {
+        return Stream.of(
+                // Payments scope, but SSA does not have PISP (payments) role
+                arguments(List.of(SCOPE_PAYMENTS),
+                          List.of(ROLE_AISP, ROLE_CBPII),
+                          INVALID_CLIENT_METADATA,
+                          "contains scopes (%s) not allowed for the presented software statement (%s)"
+                                  .formatted(SCOPE_PAYMENTS, ROLE_PISP)),
+                // Accounts scope, but SSA does not have AISP (accounts) role
+                arguments(List.of(SCOPE_ACCOUNTS),
+                          List.of(ROLE_PISP, ROLE_CBPII),
+                          INVALID_CLIENT_METADATA,
+                          "contains scopes (%s) not allowed for the presented software statement (%s)"
+                                  .formatted(SCOPE_ACCOUNTS, ROLE_AISP)),
+                // Funds scope, but SSA does not have CBPII (funds) role
+                arguments(List.of(SCOPE_FUNDS),
+                          List.of(ROLE_AISP, ROLE_PISP),
+                          INVALID_CLIENT_METADATA,
+                          "contains scopes (%s) not allowed for the presented software statement (%s)"
+                                  .formatted(SCOPE_FUNDS, ROLE_CBPII)));
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidScopesAndSsaRoles")
+    void shouldFailWithIncompatibleScopesAndSsaRoles(final List<String> scopes,
+                                                     final List<String> ssaRoles,
+                                                     final ErrorCode expectedErrorCode,
+                                                     final String expectedErrorMessage) throws IOException {
+        //Given
+        when(mockRegistrationRequest.getScope()).thenReturn(String.join(" ", scopes));
+        when(mockRegistrationRequest.getSoftwareStatement()).thenReturn(softwareStatement);
+        when(softwareStatement.getRoles()).thenReturn(ssaRoles);
+        // When
+        Response response = scopeValidationFilter.filter(context, request, next).getOrThrowIfInterrupted();
+        // Then
+        verifyNoInteractions(next);
+        assertThat(response.getEntity().getJson())
+                .asInstanceOf(type(JsonValue.class))
+                .satisfies(errorResponseJson -> {
+                    assertThat(errorResponseJson.get("error").asString()).isEqualTo(expectedErrorCode.toString());
+                    assertThat(errorResponseJson.get("error_description").asString()).contains(expectedErrorMessage);
+                });
+    }
+
+    @Test
+    void shouldFailIfNoScopesSupplied() throws IOException {
+        // Given - empty SSA roles (optional, but not null)
+        when(mockRegistrationRequest.getScope()).thenReturn(SCOPE_PAYMENTS);
+        when(mockRegistrationRequest.getSoftwareStatement()).thenReturn(softwareStatement);
+        when(softwareStatement.getRoles()).thenReturn(emptyList());
+        // When
+        Response response = scopeValidationFilter.filter(context, request, next).getOrThrowIfInterrupted();
+        // Then
+        verifyNoInteractions(next);
+        assertThat(response.getEntity().getJson())
+                .asInstanceOf(type(JsonValue.class))
+                .satisfies(errorResponseJson -> {
+                    assertThat(errorResponseJson.get("error").asString())
+                            .isEqualTo(INVALID_SOFTWARE_STATEMENT.toString());
+                    assertThat(errorResponseJson.get("error_description").asString())
+                            .contains("The software_statement jwt does not contain a 'software_roles' claim");
+                });
+    }
+
+    @Test
+    void shouldFailIfNoSsaRoles() throws IOException {
+        // Given - no scope supplied on request
+        when(mockRegistrationRequest.getScope()).thenReturn(null);
+        // When
+        Response response = scopeValidationFilter.filter(context, request, next).getOrThrowIfInterrupted();
+        // Then
+        verifyNoInteractions(next);
+        assertThat(response.getEntity().getJson())
+                .asInstanceOf(type(JsonValue.class))
+                .satisfies(errorResponseJson -> {
+                    assertThat(errorResponseJson.get("error").asString())
+                            .isEqualTo(INVALID_CLIENT_METADATA.toString());
+                    assertThat(errorResponseJson.get("error_description").asString())
+                            .contains("The request jwt does not contain the required scopes claim");
+                });
+    }
+}


### PR DESCRIPTION
- Reintroduce validator as filter `RegistrationRequestRoleBasedScopeValidationFilter`
- Prevent removal of protection for ITSS
- Previously part or `ProcessRegistration` script [here](https://github.com/SecureApiGateway/secure-api-gateway-fapi-pep-as/pull/131/files#diff-080d494d7c8b1c1df7134958c022876c71a99e2c0b1c3180af733732e87ce6c7L276)
- This should really reside in OBUK AS, but reinstating this in SAPIG-core as we don't currently have that env

Previously part of OPENIG-9136.