### PR TITLE
OPENIG-10326 Update trusted directory JWKS URL to new API endpoint

### DIFF
--- a/secure-api-gateway-fapi-pep-as-docker/src/main/resources/routes/services.json
+++ b/secure-api-gateway-fapi-pep-as-docker/src/main/resources/routes/services.json
@@ -257,7 +257,7 @@
               {
                 "type": "JwkSetSecretStore",
                 "config": {
-                  "jwkUrl": "https://&{test.directory.fqdn}/jwkms/testdirectory/jwks",
+                  "jwkUrl": "https://&{test.directory.fqdn}/api/directory/jwks",
                   "handler": "OBClientHandler"
                 }
               }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                    
  - Update `SecureAPIGatewayTestDirectory` JWKS URL from `/jwkms/testdirectory/jwks` to `/api/directory/jwks` in `services.json`                                                                                                
  - The Sample Trusted Directory REST API was refactored in OPENIG-10326 and the old `/jwkms/testdirectory/jwks` endpoint no longer exists                                                                                      
                                                                                                                                                                                                                                
  ## Test plan                                                                                                                                                                                                                  
  - [ ] Deploy pep-as with this change to a dev environment                                                                                                                                                                     
  - [ ] Confirm DCR registration with an SSA issued by the sample trusted directory succeeds (no `invalid_software_statement` error)   