### PR TITLE
OPENIG-10328 Bump SAPIG versions for dev after release of SAPIG 5.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-parent</artifactId>
-        <version>5.2.0-SNAPSHOT</version>
+        <version>5.3.0-SNAPSHOT</version>
     </parent>
     <artifactId>secure-api-gateway-fapi-pep-as</artifactId>
     <packaging>pom</packaging>

--- a/secure-api-gateway-fapi-pep-as-docker/pom.xml
+++ b/secure-api-gateway-fapi-pep-as-docker/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-fapi-pep-as</artifactId>
-        <version>5.2.0-SNAPSHOT</version>
+        <version>5.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Post-release version bump to 5.3.0-SNAPSHOT / IG 2026.6.0-SNAPSHOT. Part of SAPIG 5.2.0 release.